### PR TITLE
Tag extending

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -104,6 +104,12 @@ declare namespace parse {
      * `true` to trim whitespace at the start of each line, `false` otherwise.
      */
     trim: boolean;
+    /**
+     * Can return `"ongoing"` so as to prevent the current line from being
+     * interpreted as a new jsdoc tag; can be set to another value to
+     * indicate that new tags can now be created.
+     */
+    check: (source: string, tag: Tag) => "ongoing"|any;
   }
 
     /**

--- a/parser.js
+++ b/parser.js
@@ -86,13 +86,20 @@ function parse_block (source, opts) {
     .reduce(function (tags, line) {
       line.source = trim(line.source)
 
-      if (line.source.match(/^\s*@(\S+)/)) {
+      const tag = tags[tags.length - 1]
+
+      let extensionState
+      if (typeof opts.check === 'function') {
+        extensionState = opts.check(line.source, tag)
+      }
+
+      if (extensionState !== 'ongoing' && line.source.match(/^\s*@(\S+)/)) {
         tags.push({
           source: [line.source],
-          line: line.number
+          line: line.number,
+          extensionState
         })
       } else {
-        const tag = tags[tags.length - 1]
         if (opts.join !== undefined && opts.join !== false && opts.join !== 0 &&
             !line.startWithStar && tag.source.length > 0) {
           let source


### PR DESCRIPTION
This PR is a proposed way to fix #61.

- Allow option to track state for a tag such that a tag can be extended to include jsdoc-like items such as decorators (rather than interpreting the decorator as a tag)

I haven't added a test, as I wanted to see if you were ok with the API, but I was able to successfully meet our needs using the following code against this simple PR, calling from our code `parse` with this particular example of the new `check` option:

```js
{
check (source, tag) {
      // If this is a new `@example` (whether not preceded by another
      //   or after one, including even one which had no closing of its
      //   fenced block)...
      if (source.match(/^@example\s/)) {
        // ...and it starts a new fenced block
        if (source.includes('```')) {
          // ...we need to allow its state to be returned for
          //   preservation with the tag.

          return 'started';
        }

        // ...we allow a new tag to be created by avoiding
        //  returning any previous `"ongoing"` state
        return false;
      }

      // As we know this is not a new `@example`, this current line is
      //   part of an already-started `@example`...
      if (
        tag.source[0] && tag.source[0].match(/^@example\s/)
      ) {
        // ...so we need to change state if a fenced block is detected
        if (source.includes('```')) {
          if (
            // If a fenced block had already begun...
            tag.extensionState === 'started' || tag.extensionState === 'ongoing'
          ) {
            //   ...we know the presence of a fenced block marker means the
            //   block is closing, so set `ended` state so new tags can
            //   subsequently be created.
            tag.extensionState = 'ended';

            return false;
          }

          // A new fenced block has begun so prevent new non-example tags
          tag.extensionState = 'ongoing';

          return false;
        } else if (tag.extensionState === 'started') {
          // Label the tag `ongoing` and return it (see below)
          tag.extensionState = 'ongoing';
        }
      }

      // Return `extensionState` in case a fenced block is still ongoing
      //  and we don't want new jsdoc-like tags such as decorators to be
      // treated as jsdoc tags
      return tag.extensionState;
    }
}
```