### PR TITLE
fix: ensure non-space characters immediately after asterisk are included in source

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -237,7 +237,9 @@ function mkextract (opts) {
       // it always has the right indentation
       if (chunk.length > 0 && nonSpaceChar) {
         if (nonSpaceChar[0] === '*') {
-          lineStart = nonSpaceChar.index + 2
+          const afterNonSpaceCharIdx = nonSpaceChar.index + 1
+          const extraCharIsSpace = line.charAt(afterNonSpaceCharIdx) === ' '
+          lineStart = afterNonSpaceCharIdx + (extraCharIsSpace ? 1 : 0)
           startWithStar = true
         } else if (nonSpaceChar.index < indent) {
           lineStart = nonSpaceChar.index

--- a/tests/parse.spec.js
+++ b/tests/parse.spec.js
@@ -1081,6 +1081,31 @@ describe('Comment string parsing', function () {
       })
   })
 
+  it('should include non-space immediately after asterisk`', function () {
+    expect(parse(function () {
+      /**
+       * @example
+       *```typescript
+       * ```
+       */
+      function A () {}
+    })[0])
+      .to.eql({
+        line: 1,
+        source: '@example\n```typescript\n```',
+        description: '',
+        tags: [{
+          tag: 'example',
+          name: '\n```typescript',
+          optional: false,
+          description: '```',
+          type: '',
+          line: 2,
+          source: '@example\n```typescript\n```'
+        }]
+      })
+  })
+
   it('should handle fenced description (issue #61)`', function () {
     expect(parse(function () {
       /**


### PR DESCRIPTION
This addresses an issue that came up for us at https://github.com/gajus/eslint-plugin-jsdoc/issues/443 .

I wouldn't think non-whitespace content should be auto-stripped, so this only skips a single space. (Let me know if you want it to strip tabs or other whitespace.)