### PR TITLE
Parser coverage

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules/*
+coverage

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ results
 package-lock.json
 npm-debug.log
 node_modules
+.nyc_output
 
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ package-lock.json
 npm-debug.log
 node_modules
 .nyc_output
+coverage
 
 .vscode

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+tests
+.nyc_output
+.travis.yml

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 tests
 .nyc_output
 .travis.yml
+coverage

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "eslint-plugin-standard": "^4.0.1",
     "mocha": "^6.2.2",
     "nodemon": "^1.19.4",
+    "nyc": "^14.1.1",
     "typescript": "^3.6.4"
   },
   "engines": {
@@ -28,9 +29,14 @@
     "lint:fix": "eslint --fix .",
     "test:lint": "eslint .",
     "test:typescript": "tsc index.d.ts",
-    "test:unit": "mocha tests",
+    "test:unit": "nyc mocha tests",
     "test": "npm run test:typescript && npm run test:lint && npm run test:unit",
     "watch": "nodemon -q -i node_modules -x npm test"
+  },
+  "nyc": {
+    "exclude": [
+      "tests"
+    ]
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "mocha": "^6.2.2",
+    "node-static": "^0.7.11",
     "nodemon": "^1.19.4",
     "nyc": "^14.1.1",
+    "open-cli": "^5.0.0",
     "typescript": "^3.6.4"
   },
   "engines": {
@@ -26,6 +28,8 @@
   },
   "scripts": {
     "typescript": "tsc index.d.ts",
+    "start": "static -p 8065",
+    "cov:open": "open-cli http://localhost:8065/coverage/ && npm start",
     "lint:fix": "eslint --fix .",
     "test:lint": "eslint .",
     "test:typescript": "tsc index.d.ts",
@@ -36,6 +40,10 @@
   "nyc": {
     "exclude": [
       "tests"
+    ],
+    "reporter": [
+      "text",
+      "html"
     ]
   },
   "repository": {

--- a/parser.js
+++ b/parser.js
@@ -14,11 +14,9 @@ function find (list, filter) {
   let matchs = true
 
   while (i--) {
-    for (const k in filter) {
-      if ({}.hasOwnProperty.call(filter, k)) {
-        matchs = (filter[k] === list[i][k]) && matchs
-      }
-    }
+    Object.keys(filter).forEach((k) => {
+      matchs = (filter[k] === list[i][k]) && matchs
+    })
     if (matchs) { return list[i] }
   }
   return null
@@ -33,7 +31,10 @@ function find (list, filter) {
  * @returns {object} parsed tag node
  */
 function parse_tag (str, parsers) {
-  if (typeof str !== 'string' || str[0] !== '@') { return null }
+  // Should not get here as enforcing that string begin with whitespace
+  //  and an at-sign
+  /* istanbul ignore next */
+  if (typeof str !== 'string' || !(/\s*@/).test(str)) { return null }
 
   const data = parsers.reduce(function (state, parser) {
     let result
@@ -140,6 +141,9 @@ function parse_block (source, opts) {
   const tags = source.reduce(function (tags, tag) {
     const tag_node = parse_tag(tag.source, opts.parsers)
 
+    // Should not get here as enforcing that string begin with whitespace
+    //  and an at-sign and return non-nullish value
+    /* istanbul ignore next */
     if (!tag_node) { return tags }
 
     tag_node.line = tag.line

--- a/parsers.js
+++ b/parsers.js
@@ -5,6 +5,10 @@ function skipws (str) {
   do {
     if (str[i] !== ' ' && str[i] !== '\t') { return i }
   } while (++i < str.length)
+  // When not trimming, `str` will always end with a newline, and when
+  //  trimming, will end with end-of-string, so this `return` is not
+  //  really needed
+  /* istanbul ignore next */
   return i
 }
 
@@ -15,6 +19,8 @@ const PARSERS = {}
 PARSERS.parse_tag = function parse_tag (str) {
   const result = str.match(/^\s*@(\S+)/)
 
+  // If there is no at-sign or not followed by non-whitespace, won't get here
+  /* istanbul ignore next */
   if (!result) { throw new Error('Invalid `@tag`, missing @ symbol') }
 
   return {

--- a/tests/custom-parsers.spec.js
+++ b/tests/custom-parsers.spec.js
@@ -3,6 +3,7 @@
 
 const { expect } = require('chai')
 const parse = require('./parse')
+const builtinParsers = require('../parsers')
 
 describe('parse() with custom tag parsers', function () {
   function sample () {
@@ -123,6 +124,43 @@ describe('parse() with custom tag parsers', function () {
           source: '@tag {type} name description',
           errors: [
             'parser2: error 1',
+            'parser3: error 2'
+          ],
+          line: 2
+        }]
+      })
+  })
+
+  it('should catch parser exceptions and populate `errors` field (with built-in `parse_type`)', function () {
+    const parsers = [
+      function parser1 (str) {
+        throw new Error('error 1')
+      },
+      builtinParsers.parse_type,
+      function parser3 (str) {
+        throw new Error('error 2')
+      },
+      function parser4 (str) {
+        return {
+          source: '',
+          data: { name: 'name' }
+        }
+      }
+    ]
+
+    expect(parse(sample, { parsers: parsers })[0])
+      .to.eql({
+        line: 1,
+        description: '',
+        source: '@tag {type} name description',
+        tags: [{
+          type: '',
+          name: 'name',
+          description: '',
+          optional: false,
+          source: '@tag {type} name description',
+          errors: [
+            'parser1: error 1',
             'parser3: error 2'
           ],
           line: 2

--- a/tests/files.spec.js
+++ b/tests/files.spec.js
@@ -34,6 +34,32 @@ describe('File parsing', function () {
     })
   })
 
+  it('should parse the file by path (with stream options argument)', function (done) {
+    parse.file(path.resolve(__dirname, 'fixtures/sample.js'), {}, function (err, parsed) {
+      if (err) { done(err) }
+
+      expect(parsed)
+        .to.be.an('array')
+
+      expect(parsed.length)
+        .to.eq(4)
+
+      expect(parsed[0].description)
+        .to.eq('File description')
+
+      expect(parsed[1].tags[0].tag)
+        .to.eq('class')
+
+      expect(parsed[2].tags[0].tag)
+        .to.eq('property')
+
+      expect(parsed[3].tags[0].tag)
+        .to.eq('method')
+
+      done()
+    })
+  })
+
   it('should path the error if file dows not exist', function (done) {
     parse.file('does/not/exists', function (err, parsed) {
       expect(err)

--- a/tests/parse.js
+++ b/tests/parse.js
@@ -12,9 +12,12 @@
 const parse = require('../index')
 
 module.exports = function (func, opts) {
-  let str = func.toString()
-  str = str
-    .slice(str.indexOf('{') + 1, str.lastIndexOf('}'))
-    .replace(/\r\n/g, '\n')
+  let str = func
+  if (typeof func === 'function') {
+    str = func.toString()
+    str = str
+      .slice(str.indexOf('{') + 1, str.lastIndexOf('}'))
+      .replace(/\r\n/g, '\n')
+  }
   return parse(str, opts)
 }

--- a/tests/parse.spec.js
+++ b/tests/parse.spec.js
@@ -735,6 +735,95 @@ describe('Comment string parsing', function () {
       })
   })
 
+  it('should parse nested tags with missing parent', function () {
+    expect(parse(function () {
+      /**
+       * Description
+       * @my-tag name.sub-name
+       * @my-tag name.sub-name.sub-sub-name
+       */
+    }, { dotted_names: true })[0])
+      .to.eql({
+        line: 1,
+        description: 'Description',
+        source: 'Description\n@my-tag name.sub-name\n@my-tag name.sub-name.sub-sub-name',
+        tags: [{
+          tag: 'my-tag',
+          line: 3,
+          type: '',
+          name: 'name',
+          description: '',
+          tags: [{
+            tag: 'my-tag',
+            line: 3,
+            type: '',
+            name: 'sub-name',
+            optional: false,
+            source: '@my-tag name.sub-name',
+            description: '',
+            tags: [{
+              tag: 'my-tag',
+              line: 4,
+              type: '',
+              name: 'sub-sub-name',
+              optional: false,
+              source: '@my-tag name.sub-name.sub-sub-name',
+              description: ''
+            }]
+          }]
+        }]
+      })
+  })
+
+  it('should parse nested tags with missing parent but with matching tag name', function () {
+    expect(parse(function () {
+      /**
+       * Description
+       * @my-tag
+       * @my-tag name.sub-name
+       * @my-tag name.sub-name.sub-sub-name
+       */
+    }, { dotted_names: true })[0])
+      .to.eql({
+        line: 1,
+        description: 'Description',
+        source: 'Description\n@my-tag\n@my-tag name.sub-name\n@my-tag name.sub-name.sub-sub-name',
+        tags: [{
+          tag: 'my-tag',
+          line: 3,
+          type: '',
+          name: '',
+          source: '@my-tag',
+          optional: false,
+          description: ''
+        }, {
+          tag: 'my-tag',
+          line: 4,
+          type: '',
+          name: 'name',
+          description: '',
+          tags: [{
+            tag: 'my-tag',
+            line: 4,
+            type: '',
+            name: 'sub-name',
+            optional: false,
+            source: '@my-tag name.sub-name',
+            description: '',
+            tags: [{
+              tag: 'my-tag',
+              line: 5,
+              type: '',
+              name: 'sub-sub-name',
+              optional: false,
+              source: '@my-tag name.sub-name.sub-sub-name',
+              description: ''
+            }]
+          }]
+        }]
+      })
+  })
+
   it('should parse complex types `@tag {{a: type}} name`', function () {
     expect(parse(function () {
       /**
@@ -973,6 +1062,31 @@ describe('Comment string parsing', function () {
           description: 'description  intent same line\n',
           source: '@tag name\ndescription  intent same line\n',
           optional: false
+        }]
+      })
+  })
+
+  it('should parse doc block with star and initial whitespace respecting `opts.trim = false`', function () {
+    expect(parse(function () {
+      /**
+       * Description text
+       *  @tag tagname Tag description
+       */
+    }, {
+      trim: false
+    })[0])
+      .to.eql({
+        description: '\nDescription text',
+        source: '\nDescription text\n @tag tagname Tag description\n',
+        line: 1,
+        tags: [{
+          tag: 'tag',
+          name: 'tagname',
+          optional: false,
+          description: 'Tag description\n',
+          type: '',
+          line: 3,
+          source: ' @tag tagname Tag description\n'
         }]
       })
   })

--- a/tests/parse.spec.js
+++ b/tests/parse.spec.js
@@ -391,6 +391,29 @@ describe('Comment string parsing', function () {
   })
   /* eslint-enable no-tabs */
 
+  it('should parse tag with whitespace description and `opts.trim = false`', function () {
+    expect(parse(`
+      /**
+       * @my-tag {my.type} name\t
+       */
+    `, { trim: false })[0])
+      .to.eql({
+        line: 1,
+        source: '\n@my-tag {my.type} name\t\n',
+        description: '',
+        tags: [{
+          tag: 'my-tag',
+          line: 2,
+          type: 'my.type',
+          name: 'name',
+          source: '@my-tag {my.type} name\t\n',
+          // Default parser trims regardless of `trim` setting
+          description: '',
+          optional: false
+        }]
+      })
+  })
+
   it('should parse tag with multiline description', function () {
     expect(parse(function () {
       /**
@@ -411,6 +434,29 @@ describe('Comment string parsing', function () {
           source: '@my-tag {my.type} name description line 1\ndescription line 2\ndescription line 3',
           description: 'description line 1\ndescription line 2\ndescription line 3',
           optional: false
+        }]
+      })
+  })
+
+  it('should gracefully fail on syntax errors `@tag [name`', function () {
+    expect(parse(function () {
+      /**
+       * @my-tag [name
+       */
+    })[0])
+      .to.eql({
+        line: 1,
+        description: '',
+        source: '@my-tag [name',
+        tags: [{
+          tag: 'my-tag',
+          line: 2,
+          type: '',
+          name: '',
+          description: '',
+          source: '@my-tag [name',
+          optional: false,
+          errors: ['parse_name: Invalid `name`, unpaired brackets']
         }]
       })
   })


### PR DESCRIPTION
Builds on #71 . Brings coverage to 100% on `parser.js` file.

Also gives fix to properly allow additional initial whitespace after asterisk.