### PR TITLE
fix: multiline descriptions

### DIFF
--- a/stringifier.js
+++ b/stringifier.js
@@ -33,7 +33,7 @@ const stringifyBlock = exports.stringifyBlock = function stringifyBlock (
 ) {
   // block.line
   const indnt = getIndent(indent)
-  return (block.description ? `${indnt}* ${block.description}\n${indnt}*\n` : '') +
+  return (block.description ? `${indnt}${block.description.replace(/^/gm, '* ')}\n${indnt}*\n` : '') +
     block.tags.reduce((s, tag) => {
       return s + stringifyTag(tag, { indent })
     }, '')

--- a/tests/stringify.spec.js
+++ b/tests/stringify.spec.js
@@ -25,6 +25,27 @@ describe('Comment stringifying', function () {
     expect(stringified).to.eq(expected)
   })
 
+  it('should stringify doc block with multiline description', function () {
+    const expected = `/**
+* Singleline or multiline description text. Line breaks are preserved.
+* Multiline descriptions are preserved.
+*
+* @some-tag {Type} name Singleline or multiline description text
+* @some-tag {Type} name.subname Singleline or multiline description text
+* @some-tag {Type} name.subname.subsubname Singleline or
+* multiline description text
+* @some-tag {Type} [optionalName=someDefault]
+* @another-tag
+*/`
+    const parsed = parser(expected)
+
+    expect(parsed).to.be.an('array')
+
+    const stringified = parser.stringify(parsed)
+
+    expect(stringified).to.eq(expected)
+  })
+
   it('should stringify doc block with description (supplied tags object)', function () {
     const expected = `* Singleline or multiline description text. Line breaks are preserved.
 *


### PR DESCRIPTION
Previously, the asterisks on subsequent lines would be omitted - this preserves the property whereby `stringify(parse(str))` produces `str`.