### PR TITLE
- Fix: Change to `trimRight` for Node 6 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "typescript": "^3.8.3"
   },
   "engines": {
-    "node": ">= 6.0.0"
+    "node": ">=6.0.0"
   },
   "scripts": {
     "typescript": "tsc index.d.ts",

--- a/stringifier.js
+++ b/stringifier.js
@@ -57,7 +57,7 @@ const stringifyTag = exports.stringifyTag = function stringifyTag (
     (type ? ` {${type}}` : '') +
     (name.trim() ? ` ${
       optional ? '[' : ''
-    }${name.trimEnd()}${deflt ? `=${deflt}` : ''}${
+    }${name.trimRight()}${deflt ? `=${deflt}` : ''}${
       optional ? ']' : ''
     }` : '') +
     (description ? ` ${description.replace(/\n/g, '\n' + indnt + '* ')}` : '') + '\n'


### PR DESCRIPTION
Hi,

Thank you very much for the merge!

However, I'm sorry that I only realized after the fact that `trimEnd` is not supported in pre-Node 10, so unless you wish to bump `package.json` `engine` (and Travis) to Node 10, I think this fix will be necessary for now. (`trimRight` was supported and still is supported, but projects such as Unicorn have been discouraging it in favor of `trimEnd` where available).