### PR TITLE
- Preserve empty value for default

### DIFF
--- a/parsers.js
+++ b/parsers.js
@@ -77,13 +77,19 @@ PARSERS.parse_name = function parse_name (str, data) {
       name = name.slice(1, -1)
 
       const match = name.match(
-        /^\s*([^=]+?)(?:\s*=\s*(.+?))?\s*(?=$)/
+        /^\s*([^=]+?)(?:\s*=\s*(.*?))?\s*(?=$)/
       )
 
       if (!match) throw new SyntaxError('Invalid `name`, bad syntax')
 
       name = match[1]
       if (match[2]) res.default = match[2]
+      // We will throw this later after processing other tags (so we
+      //  will collect enough data for the user to be able to fully recover)
+      else if (match[2] === '') {
+        res.default = match[2]
+        res.warning = 'Empty `name`, bad syntax'
+      }
     }
   }
 

--- a/stringifier.js
+++ b/stringifier.js
@@ -57,7 +57,7 @@ const stringifyTag = exports.stringifyTag = function stringifyTag (
     (type ? ` {${type}}` : '') +
     (name.trim() ? ` ${
       optional ? '[' : ''
-    }${name.trimRight()}${deflt ? `=${deflt}` : ''}${
+    }${name.trimRight()}${deflt !== undefined ? `=${deflt}` : ''}${
       optional ? ']' : ''
     }` : '') +
     (description ? ` ${description.replace(/\n/g, '\n' + indnt + '* ')}` : '') + '\n'

--- a/tests/parse.spec.js
+++ b/tests/parse.spec.js
@@ -476,11 +476,12 @@ describe('Comment string parsing', function () {
         tag: 'my-tag',
         line: 2,
         type: '',
-        name: '',
+        name: 'name',
         source: '@my-tag [name=]',
+        default: '',
         description: '',
-        optional: false,
-        errors: ['parse_name: Invalid `name`, bad syntax']
+        optional: true,
+        errors: ['parse_name: Empty `name`, bad syntax']
       }]
     }])
   })

--- a/tests/stringify.spec.js
+++ b/tests/stringify.spec.js
@@ -25,6 +25,27 @@ describe('Comment stringifying', function () {
     expect(stringified).to.eq(expected)
   })
 
+  it('should allow stringifying doc block with description after recovery', function () {
+    const expected = `/**
+* Singleline or multiline description text. Line breaks are preserved.
+*
+* @some-tag {Type} name Singleline or multiline description text
+* @some-tag {Type} name.subname Singleline or multiline description text
+* @some-tag {Type} name.subname.subsubname Singleline or
+* multiline description text
+* @some-tag {Type} [optionalName=someDefault]
+* @emptyDefaultTag {Type} [optionalName=] Some desc.
+* @another-tag
+*/`
+    const parsed = parser(expected, { trim: false })
+
+    expect(parsed).to.be.an('array')
+
+    const stringified = parser.stringify(parsed)
+
+    expect(stringified).to.eq(expected)
+  })
+
   it('should stringify doc block with multiline description', function () {
     const expected = `/**
 * Singleline or multiline description text. Line breaks are preserved.


### PR DESCRIPTION
In looking at the change in #87 to preserve quotes, I took a look at the stringifier, and see if the stringifier should continue to work as is with the changes--and it does.

In fact, if that PR is not accepted for some reason, I see there is a preexisting problem with the stringifier too if an empty string default like `@param [someName='']` is given, as the stripping of quotes would cause the default value to become falsey and the default dropped entirely.

However, even if the PR is accepted (and I think it is a reasonable change), there is still the case that `* @param [name=]` would have the default dropped, and I think it would be more faithful to whatever intent the doc author had to ensure the stringifer doesn't drop even that.

This PR will thus fix either case.