### PR TITLE
- Fix: Allow `/**` within description

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -215,7 +215,7 @@ function mkextract (opts) {
     const endPos = line.indexOf(MARKER_END)
 
     // if open marker detected and it's not, skip one
-    if (startPos !== -1 && line.indexOf(MARKER_START_SKIP) !== startPos) {
+    if (!chunk && startPos !== -1 && line.indexOf(MARKER_START_SKIP) !== startPos) {
       chunk = []
       indent = startPos + MARKER_START.length
     }

--- a/tests/parse.spec.js
+++ b/tests/parse.spec.js
@@ -367,6 +367,28 @@ describe('Comment string parsing', function () {
       }])
   })
 
+  it('should parse tag with type, name and description `@tag {my.type} name description with `/**` characters`', function () {
+    expect(parse(function () {
+      /**
+       * @my-tag {my.type} name description `/**`
+       */
+    }))
+      .to.eql([{
+        line: 1,
+        source: '@my-tag {my.type} name description `/**`',
+        description: '',
+        tags: [{
+          tag: 'my-tag',
+          line: 2,
+          type: 'my.type',
+          name: 'name',
+          source: '@my-tag {my.type} name description `/**`',
+          description: 'description `/**`',
+          optional: false
+        }]
+      }])
+  })
+
   it('should parse tag with type, name and description separated by tab `@tag {my.type} name  description`', function () {
     expect(parse(
       /* eslint-disable no-tabs */


### PR DESCRIPTION
A user is in need of a marker start inside a jsdoc block: https://github.com/gajus/eslint-plugin-jsdoc/issues/568.

This PR adds such support.