### PR TITLE
introduce inspect() helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ const source = `
 /**
  * Description may go
  * over few lines followed by @tags
- * @param {string} name name parameter
- * @param {any} value value of any type
+ * @param {string} name the name parameter
+ * @param {any} value the value of any type
  */`
 
 const parsed = parse(source)
@@ -73,7 +73,14 @@ The input source is first parsed into lines, then lines split into tokens, and f
 ### Tokens
 
 ```
-| ... | * | ... | @param | ... | {any} | ... | value | ... | the value of any type
+|line|start|delimiter|postDelimiter|tag   |postTag|name |postName|type    |postType|description                     |end|
+|----|-----|---------|-------------|------|-------|-----|--------|--------|--------|--------------------------------|---|
+|   0|{2}  |/**      |             |      |       |     |        |        |        |                                |   |
+|   1|{3}  |*        |{1}          |      |       |     |        |        |        |Description may go              |   |
+|   2|{3}  |*        |{1}          |      |       |     |        |        |        |over few lines followed by @tags|   |
+|   3|{3}  |*        |{1}          |@param|{1}    |name |{1}     |{string}|{1}     |the name parameter              |   |
+|   4|{3}  |*        |{1}          |@param|{1}    |value|{1}     |{any}   |{1}     |the value of any type           |   |
+|   5|{3}  |         |             |      |       |     |        |        |        |                                |*/ |
 ```
 
 ### Result

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 import getParser, { Options as ParserOptions } from './parser/index';
 import getStringifier from './stringifier/index';
-import { Block } from './primitives';
 
 export function parse(source: string, options: Partial<ParserOptions> = {}) {
   return getParser(options)(source);
 }
 
 export const stringify = getStringifier();
+export { default as inspect } from './stringifier/inspect';
 
 export * as transforms from './transforms/index';

--- a/src/stringifier/inspect.ts
+++ b/src/stringifier/inspect.ts
@@ -1,0 +1,64 @@
+import { Block, Line, Tokens } from '../primitives';
+import { seedTokens, isSpace } from '../util';
+
+interface Width {
+  line: number;
+  start: number;
+  delimiter: number;
+  postDelimiter: number;
+  tag: number;
+  postTag: number;
+  name: number;
+  postName: number;
+  type: number;
+  postType: number;
+  description: number;
+  end: number;
+}
+
+const zeroWidth = {
+  line: 0,
+  start: 0,
+  delimiter: 0,
+  postDelimiter: 0,
+  tag: 0,
+  postTag: 0,
+  name: 0,
+  postName: 0,
+  type: 0,
+  postType: 0,
+  description: 0,
+  end: 0,
+};
+
+const fields = Object.keys(zeroWidth);
+
+const repr = (x: string) => (isSpace(x) ? `{${x.length}}` : x);
+
+const frame = (line: string[]) => '|' + line.join('|') + '|';
+
+const align = (width: Width, tokens: Tokens): string[] =>
+  Object.keys(tokens).map((k) => repr(tokens[k]).padEnd(width[k]));
+
+export default function inspect({ source }: Block): string {
+  if (source.length === 0) return '';
+
+  const width: Width = { ...zeroWidth };
+
+  for (const f of fields) width[f] = f.length;
+  for (const { number, tokens } of source) {
+    width.line = Math.max(width.line, number.toString().length);
+    for (const k in tokens)
+      width[k] = Math.max(width[k], repr(tokens[k]).length);
+  }
+
+  const lines: string[][] = [[], []];
+  for (const f of fields) lines[0].push(f.padEnd(width[f]));
+  for (const f of fields) lines[1].push('-'.padEnd(width[f], '-'));
+  for (const { number, tokens } of source) {
+    const line = number.toString().padStart(width.line);
+    lines.push([line, ...align(width, tokens)]);
+  }
+
+  return lines.map(frame).join('\n');
+}

--- a/tests/unit/inspect.spec.ts
+++ b/tests/unit/inspect.spec.ts
@@ -1,0 +1,36 @@
+import getParser from '../../src/parser/index';
+import inspect from '../../src/stringifier/inspect';
+
+test('multiple lines', () => {
+  const source = `
+  /**
+   * Description may go
+   * over few lines followed by @tags
+   * @param {string} name name parameter
+   * @param {any} value value of any type
+   */`.slice(1);
+
+  const parsed = getParser()(source);
+  const expected = `
+|line|start|delimiter|postDelimiter|tag   |postTag|name |postName|type    |postType|description                     |end|
+|----|-----|---------|-------------|------|-------|-----|--------|--------|--------|--------------------------------|---|
+|   0|{2}  |/**      |             |      |       |     |        |        |        |                                |   |
+|   1|{3}  |*        |{1}          |      |       |     |        |        |        |Description may go              |   |
+|   2|{3}  |*        |{1}          |      |       |     |        |        |        |over few lines followed by @tags|   |
+|   3|{3}  |*        |{1}          |@param|{1}    |name |{1}     |{string}|{1}     |name parameter                  |   |
+|   4|{3}  |*        |{1}          |@param|{1}    |value|{1}     |{any}   |{1}     |value of any type               |   |
+|   5|{3}  |         |             |      |       |     |        |        |        |                                |*/ |`;
+
+  expect(inspect(parsed[0])).toEqual(expected.slice(1));
+});
+
+test('single line', () => {
+  const source = '/** @param {string} name name parameter */';
+  const parsed = getParser({ startLine: 12345 })(source);
+  const expected = `
+|line |start|delimiter|postDelimiter|tag   |postTag|name|postName|type    |postType|description    |end|
+|-----|-----|---------|-------------|------|-------|----|--------|--------|--------|---------------|---|
+|12345|     |/**      |{1}          |@param|{1}    |name|{1}     |{string}|{1}     |name parameter |*/ |`;
+
+  expect(inspect(parsed[0])).toEqual(expected.slice(1));
+});


### PR DESCRIPTION
adding helper for printing out tokens

```ts
import inspect from './stringifier/inspect'
inspect(parsed[0])
```
produces
```
|line|start|delimiter|postDelimiter|tag   |postTag|name |postName|type    |postType|description                     |end|
|----|-----|---------|-------------|------|-------|-----|--------|--------|--------|--------------------------------|---|
|   0|{2}  |/**      |             |      |       |     |        |        |        |                                |   |
|   1|{3}  |*        |{1}          |      |       |     |        |        |        |Description may go              |   |
|   2|{3}  |*        |{1}          |      |       |     |        |        |        |over few lines followed by @tags|   |
|   3|{3}  |*        |{1}          |@param|{1}    |name |{1}     |{string}|{1}     |name parameter                  |   |
|   4|{3}  |*        |{1}          |@param|{1}    |value|{1}     |{any}   |{1}     |value of any type               |   |
|   5|{3}  |         |             |      |       |     |        |        |        |                                |*/ |
```
