### PR TITLE
Issue 129 carriage returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.1.6-beta.0
+- keep original CR line endings
+- allow to normalize line endings with `crlf` transform
+
 # v1.1.5
 - drop unused variables
 - add .editorconfig

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# v1.1.6-beta.1
+- support native ESM
 # v1.1.6-beta.0
 - keep original CR line endings
 - allow to normalize line endings with `crlf` transform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# v1.1.6-beta.2
+- ESM/CJS compatibility fixes
 # v1.1.6-beta.1
 - support native ESM
 # v1.1.6-beta.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
+# v1.1.6-beta.3
+- process CRs as a separate .lineEnd toke
+
 # v1.1.6-beta.2
 - ESM/CJS compatibility fixes
+
 # v1.1.6-beta.1
 - support native ESM
+
 # v1.1.6-beta.0
 - keep original CR line endings
 - allow to normalize line endings with `crlf` transform

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,12 +1,11 @@
 // For a detailed explanation regarding each configuration property, visit:
 // https://jestjs.io/docs/en/configuration.html
 
-import {readFileSync} from 'fs';
-const {
-  compilerOptions: tsconfig
-} = JSON.parse(readFileSync(new URL('./tsconfig.node.json', import.meta.url)));
+const { compilerOptions: tsconfig } = JSON.parse(
+  require('fs').readFileSync('./tsconfig.node.json')
+);
 
-export default {
+module.exports = {
   globals: {
     'ts-jest': {
       tsconfig,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "comment-parser",
-  "version": "1.1.6-beta.0",
+  "version": "1.1.6-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.1.6-beta.0",
+      "version": "1.1.6-beta.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^26.0.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "comment-parser",
-  "version": "1.1.5",
+  "version": "1.1.6-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.1.5",
+      "version": "1.1.6-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^26.0.23",
+        "convert-extension": "^0.3.0",
         "jest": "^27.0.5",
         "prettier": "2.3.1",
         "replace": "^1.2.1",
@@ -1453,6 +1454,25 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "node_modules/convert-extension": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/convert-extension/-/convert-extension-0.3.0.tgz",
+      "integrity": "sha512-TJ3RdeL+GXOxz4jdYntfNU2vEBb4LBJppNxVD+IVZTdqvvhfthSCSh7QHi5QxSQSzsJKc8L6FgFDmeTZ/89XGA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.0",
+        "@babel/traverse": "^7.11.0",
+        "glob": "^7.1.6",
+        "mkdirp": "^1.0.4",
+        "multiline-ts": "^2.0.0"
+      },
+      "bin": {
+        "convert-extension": "build/es5/command.cjs"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
@@ -3402,6 +3422,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/multiline-ts": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multiline-ts/-/multiline-ts-2.2.0.tgz",
+      "integrity": "sha512-3BqN9bofOFEFp5ERk4ckx8aPvpLKowZCtzKC+vG8uUssSHJCr/iaCB5QI/r0t2bdRghc4UvZXe59cOl9Ph9xrQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -5751,6 +5780,19 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "convert-extension": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/convert-extension/-/convert-extension-0.3.0.tgz",
+      "integrity": "sha512-TJ3RdeL+GXOxz4jdYntfNU2vEBb4LBJppNxVD+IVZTdqvvhfthSCSh7QHi5QxSQSzsJKc8L6FgFDmeTZ/89XGA==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.11.0",
+        "@babel/traverse": "^7.11.0",
+        "glob": "^7.1.6",
+        "mkdirp": "^1.0.4",
+        "multiline-ts": "^2.0.0"
+      }
+    },
     "convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -7225,6 +7267,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "multiline-ts": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multiline-ts/-/multiline-ts-2.2.0.tgz",
+      "integrity": "sha512-3BqN9bofOFEFp5ERk4ckx8aPvpLKowZCtzKC+vG8uUssSHJCr/iaCB5QI/r0t2bdRghc4UvZXe59cOl9Ph9xrQ==",
       "dev": true
     },
     "natural-compare": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comment-parser",
-  "version": "1.1.6-beta.0",
+  "version": "1.1.6-beta.1",
   "description": "Generic JSDoc-like comment parser",
   "type": "module",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comment-parser",
-  "version": "1.1.6-beta.2",
+  "version": "1.1.6-beta.3",
   "description": "Generic JSDoc-like comment parser",
   "type": "module",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -7,27 +7,27 @@
   "exports": {
     ".": {
       "import": "./es6/index.js",
-      "require": "./lib/index.js"
+      "require": "./lib/index.cjs"
     },
     "./primitives": {
       "import": "./es6/primitives.js",
-      "require": "./lib/primitives.js"
+      "require": "./lib/primitives.cjs"
     },
     "./util": {
       "import": "./es6/util.js",
-      "require": "./lib/util.js"
+      "require": "./lib/util.cjs"
     },
     "./parser/*": {
       "import": "./es6/parser/*.js",
-      "require": "./lib/parser/*.js"
+      "require": "./lib/parser/*.cjs"
     },
     "./stringifier/*": {
       "import": "./es6/stringifier/*.js",
-      "require": "./lib/stringifier/*.js"
+      "require": "./lib/stringifier/*.cjs"
     },
     "./transforms/*": {
       "import": "./es6/transforms/*.js",
-      "require": "./lib/transforms/*.js"
+      "require": "./lib/transforms/*.cjs"
     }
   },
   "types": "lib/index.d.ts",
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",
+    "convert-extension": "^0.3.0",
     "jest": "^27.0.5",
     "prettier": "2.3.1",
     "replace": "^1.2.1",
@@ -48,7 +49,7 @@
     "node": ">= 12.0.0"
   },
   "scripts": {
-    "build": "rimraf lib es6 browser; tsc -p tsconfig.json && tsc -p tsconfig.node.json && rollup -o browser/index.js -f iife --context window -n CommentParser es6/index.js && cd es6 && replace \"from '(\\.[^']*)'\" \"from '\\$1.js'\" * -r",
+    "build": "rimraf lib es6 browser; tsc -p tsconfig.json && tsc -p tsconfig.node.json && rollup -o browser/index.js -f iife --context window -n CommentParser es6/index.js && convert-extension cjs lib/ && cd es6 && replace \"from '(\\.[^']*)'\" \"from '\\$1.js'\" * -r --include=\"*.js\"",
     "format": "prettier --write src tests",
     "pretest": "rimraf coverage; npm run build",
     "test": "prettier --check src tests && jest --verbose",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comment-parser",
-  "version": "1.1.5",
+  "version": "1.1.6-beta.0",
   "description": "Generic JSDoc-like comment parser",
   "type": "module",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comment-parser",
-  "version": "1.1.6-beta.1",
+  "version": "1.1.6-beta.2",
   "description": "Generic JSDoc-like comment parser",
   "type": "module",
   "main": "lib/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import typeTokenizer from './parser/tokenizers/type';
 import getStringifier from './stringifier/index';
 import alignTransform from './transforms/align';
 import indentTransform from './transforms/indent';
+import crlfTransform from './transforms/crlf';
 import { flow as flowTransform } from './transforms/index';
 
 export * from './primitives';
@@ -21,6 +22,7 @@ export const transforms = {
   flow: flowTransform,
   align: alignTransform,
   indent: indentTransform,
+  crlf: crlfTransform,
 };
 
 export const tokenizers = {

--- a/src/parser/source-parser.ts
+++ b/src/parser/source-parser.ts
@@ -1,5 +1,5 @@
 import { Line, Markers, Tokens } from '../primitives';
-import { seedTokens, splitSpace } from '../util';
+import { seedTokens, splitSpace, splitCR } from '../util';
 
 export interface Options {
   startLine: number;
@@ -17,6 +17,7 @@ export default function getParser({
     let rest = source;
     const tokens: Tokens = seedTokens();
 
+    [tokens.lineEnd, rest] = splitCR(rest);
     [tokens.start, rest] = splitSpace(rest);
 
     if (

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -41,6 +41,7 @@ export interface Tokens {
   postType: string;
   description: string;
   end: string;
+  lineEnd: string;
 }
 
 export interface Problem {

--- a/src/stringifier/index.ts
+++ b/src/stringifier/index.ts
@@ -14,7 +14,8 @@ function join(tokens: Tokens): string {
     tokens.name +
     tokens.postName +
     tokens.description +
-    tokens.end
+    tokens.end +
+    tokens.lineEnd
   );
 }
 

--- a/src/stringifier/inspect.ts
+++ b/src/stringifier/inspect.ts
@@ -14,6 +14,7 @@ interface Width {
   postType: number;
   description: number;
   end: number;
+  lineEnd: number;
 }
 
 const zeroWidth = {
@@ -29,7 +30,10 @@ const zeroWidth = {
   postType: 0,
   description: 0,
   end: 0,
+  lineEnd: 0,
 };
+
+const headers = { lineEnd: 'CR' };
 
 const fields = Object.keys(zeroWidth);
 
@@ -45,7 +49,7 @@ export default function inspect({ source }: Block): string {
 
   const width: Width = { ...zeroWidth };
 
-  for (const f of fields) width[f] = f.length;
+  for (const f of fields) width[f] = (headers[f] ?? f).length;
   for (const { number, tokens } of source) {
     width.line = Math.max(width.line, number.toString().length);
     for (const k in tokens)
@@ -53,7 +57,7 @@ export default function inspect({ source }: Block): string {
   }
 
   const lines: string[][] = [[], []];
-  for (const f of fields) lines[0].push(f.padEnd(width[f]));
+  for (const f of fields) lines[0].push((headers[f] ?? f).padEnd(width[f]));
   for (const f of fields) lines[1].push('-'.padEnd(width[f], '-'));
   for (const { number, tokens } of source) {
     const line = number.toString().padStart(width.line);

--- a/src/transforms/align.ts
+++ b/src/transforms/align.ts
@@ -1,6 +1,6 @@
 import { Transform } from './index';
 import { Markers, Block, Line } from '../primitives';
-import { hasCR, isSpace, rewireSource } from '../util';
+import { rewireSource } from '../util';
 
 interface Width {
   start: number;
@@ -25,8 +25,6 @@ const getWidth = (w: Width, { tokens: t }: Line) => ({
 
 const space = (len: number) => ''.padStart(len, ' ');
 
-const isEmpty = (s) => s === '' || isSpace(s);
-
 export default function align(): Transform {
   let intoTags = false;
   let w: Width;
@@ -35,14 +33,14 @@ export default function align(): Transform {
     const tokens = { ...line.tokens };
     if (tokens.tag !== '') intoTags = true;
 
+    const isEmpty =
+      tokens.tag === '' &&
+      tokens.name === '' &&
+      tokens.type === '' &&
+      tokens.description === '';
+
     // dangling '*/'
-    if (
-      tokens.end === Markers.end &&
-      isEmpty(tokens.tag) &&
-      isEmpty(tokens.name) &&
-      isEmpty(tokens.type) &&
-      isEmpty(tokens.description)
-    ) {
+    if (tokens.end === Markers.end && isEmpty) {
       tokens.start = space(w.start + 1);
       return { ...line, tokens };
     }
@@ -60,9 +58,7 @@ export default function align(): Transform {
     }
 
     if (!intoTags) {
-      tokens.postDelimiter = ' ';
-      if (isEmpty(tokens.description))
-        tokens.postDelimiter = hasCR(tokens.description) ? '\r' : '';
+      tokens.postDelimiter = tokens.description === '' ? '' : ' ';
       return { ...line, tokens };
     }
 

--- a/src/transforms/crlf.ts
+++ b/src/transforms/crlf.ts
@@ -1,0 +1,38 @@
+import { Transform } from './index';
+import { Block, Line } from '../primitives';
+import { rewireSource } from '../util';
+
+const order = [
+  'end',
+  'description',
+  'postType',
+  'type',
+  'postName',
+  'name',
+  'postTag',
+  'tag',
+  'postDelimiter',
+  'delimiter',
+  'start',
+];
+
+export type Ending = 'LF' | 'CRLF';
+
+export default function crlf(ending: Ending): Transform {
+  const normalize = (source: string): string =>
+    source.replace(/\r*$/, ending === 'LF' ? '' : '\r');
+
+  function update(line: Line): Line {
+    const { tokens } = line;
+    for (const f of order) {
+      if (tokens[f] !== '') {
+        tokens[f] = normalize(tokens[f]);
+        break;
+      }
+    }
+    return { ...line, tokens };
+  }
+
+  return ({ source, ...fields }: Block): Block =>
+    rewireSource({ ...fields, source: source.map(update) });
+}

--- a/src/transforms/crlf.ts
+++ b/src/transforms/crlf.ts
@@ -19,18 +19,11 @@ const order = [
 export type Ending = 'LF' | 'CRLF';
 
 export default function crlf(ending: Ending): Transform {
-  const normalize = (source: string): string =>
-    source.replace(/\r*$/, ending === 'LF' ? '' : '\r');
-
   function update(line: Line): Line {
-    const { tokens } = line;
-    for (const f of order) {
-      if (tokens[f] !== '') {
-        tokens[f] = normalize(tokens[f]);
-        break;
-      }
-    }
-    return { ...line, tokens };
+    return {
+      ...line,
+      tokens: { ...line.tokens, lineEnd: ending === 'LF' ? '' : '\r' },
+    };
   }
 
   return ({ source, ...fields }: Block): Block =>

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,7 +12,7 @@ export function splitSpace(source: string): [string, string] {
 }
 
 export function splitLines(source: string): string[] {
-  return source.split(/\r?\n/);
+  return source.split(/\n/);
 }
 
 export function seedBlock(block: Partial<Block> = {}): Block {

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,6 +4,10 @@ export function isSpace(source: string): boolean {
   return /^\s+$/.test(source);
 }
 
+export function hasCR(source: string): boolean {
+  return /\r$/.test(source);
+}
+
 export function splitSpace(source: string): [string, string] {
   const matches = source.match(/^\s+/);
   return matches == null

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,6 +8,13 @@ export function hasCR(source: string): boolean {
   return /\r$/.test(source);
 }
 
+export function splitCR(source: string): [string, string] {
+  const matches = source.match(/\r+$/);
+  return matches == null
+    ? ['', source]
+    : [source.slice(-matches[0].length), source.slice(0, -matches[0].length)];
+}
+
 export function splitSpace(source: string): [string, string] {
   const matches = source.match(/^\s+/);
   return matches == null
@@ -55,6 +62,7 @@ export function seedTokens(tokens: Partial<Tokens> = {}): Tokens {
     postType: '',
     description: '',
     end: '',
+    lineEnd: '',
     ...tokens,
   };
 }

--- a/tests/e2e/examples.spec.js
+++ b/tests/e2e/examples.spec.js
@@ -1,4 +1,9 @@
-const { parse, stringify, transforms, tokenizers } = require('../../lib');
+const {
+  parse,
+  stringify,
+  transforms,
+  tokenizers,
+} = require('../../lib/index.cjs');
 const { examples } = require('./examples');
 
 const table = examples.map((fn) => [fn.name.replace(/_/g, ' '), fn]);

--- a/tests/e2e/issue-109.spec.js
+++ b/tests/e2e/issue-109.spec.js
@@ -1,4 +1,4 @@
-const { parse, inspect } = require('../../lib');
+const { parse, inspect } = require('../../lib/index.cjs');
 
 const source = `
   /**

--- a/tests/e2e/issue-112.spec.js
+++ b/tests/e2e/issue-112.spec.js
@@ -1,4 +1,4 @@
-const { parse, inspect } = require('../../lib');
+const { parse, inspect } = require('../../lib/index.cjs');
 
 const source = `
   /**

--- a/tests/e2e/issue-113.spec.js
+++ b/tests/e2e/issue-113.spec.js
@@ -1,4 +1,4 @@
-const { parse, inspect } = require('../../lib');
+const { parse, inspect } = require('../../lib/index.cjs');
 
 const source = `
   /** Multi-line typedef for an options object type.

--- a/tests/e2e/issue-119.spec.js
+++ b/tests/e2e/issue-119.spec.js
@@ -2,7 +2,7 @@ const {
   parse,
   stringify,
   transforms: { align },
-} = require('../../lib');
+} = require('../../lib/index.cjs');
 
 test('align - ignore trailing right space', () => {
   const source = `

--- a/tests/e2e/issue-120.spec.js
+++ b/tests/e2e/issue-120.spec.js
@@ -2,7 +2,7 @@ const {
   parse,
   stringify,
   transforms: { align },
-} = require('../../lib');
+} = require('../../lib/index.cjs');
 
 test('align - collapse postDelim', () => {
   const source = `

--- a/tests/e2e/issue-121.spec.js
+++ b/tests/e2e/issue-121.spec.js
@@ -1,4 +1,4 @@
-const { parse, inspect } = require('../../lib');
+const { parse, inspect } = require('../../lib/index.cjs');
 
 test('name cut off', () => {
   const source = `

--- a/tests/e2e/issue-121.spec.js
+++ b/tests/e2e/issue-121.spec.js
@@ -23,6 +23,7 @@ test('name cut off', () => {
         postName: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -41,6 +42,7 @@ test('name cut off', () => {
         postName: ' ',
         description: 'The options.',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -58,6 +60,7 @@ test('name cut off', () => {
         postName: '',
         description: '',
         end: '*/',
+        lineEnd: '',
       },
     },
   ];
@@ -93,6 +96,7 @@ test('name cut off', () => {
           postName: '',
           description: '',
           end: '',
+          lineEnd: '',
         },
       },
       ...tagSource,

--- a/tests/e2e/issue-129.spec.js
+++ b/tests/e2e/issue-129.spec.js
@@ -3,7 +3,7 @@ const {
   inspect,
   stringify,
   transforms: { align },
-} = require('../../lib');
+} = require('../../lib/index.cjs');
 
 const tokens = {
   start: '',
@@ -17,6 +17,7 @@ const tokens = {
   postName: '',
   description: '',
   end: '',
+  lineEnd: '',
 };
 
 test('carriage returns', () => {
@@ -45,7 +46,8 @@ test('carriage returns', () => {
         start: '     ',
         delimiter: '*',
         postDelimiter: ' ',
-        description: 'description\r',
+        description: 'description',
+        lineEnd: '\r',
       },
     },
     {
@@ -59,7 +61,7 @@ test('carriage returns', () => {
         tag: '@param0',
         postTag: ' ',
         type: '{param-type}',
-        postType: '\r',
+        lineEnd: '\r',
       },
     },
     {
@@ -76,7 +78,8 @@ test('carriage returns', () => {
         postType: ' ',
         name: 'paramName',
         postName: ' ',
-        description: 'param description\r',
+        description: 'param description',
+        lineEnd: '\r',
       },
     },
     {
@@ -125,12 +128,12 @@ test('carriage returns with alignment', () => {
       */\r`.slice(1);
 
   const expected = `
-     /**
-      * Description may go
-      * over multiple lines followed by @tags
-      * @param {string} name  the name parameter
-      * @param {any}    value
-      */`.slice(1);
+     /**\r
+      * Description may go\r
+      * over multiple lines followed by @tags\r
+      * @param {string} name  the name parameter\r
+      * @param {any}    value\r
+      */\r`.slice(1);
 
   const parsed = parse(source);
   const aligned = align()(parsed[0]);

--- a/tests/e2e/issue-129.spec.js
+++ b/tests/e2e/issue-129.spec.js
@@ -1,0 +1,111 @@
+const { parse, inspect } = require('../../lib');
+
+const tokens = {
+  start: '',
+  delimiter: '',
+  postDelimiter: '',
+  tag: '',
+  postTag: '',
+  type: '',
+  postType: '',
+  name: '',
+  postName: '',
+  description: '',
+  end: '',
+};
+
+test('carriage returns', () => {
+  const parsed = parse(`
+    /**
+     * description\r
+     * @param0 {param-type}\r
+     * @param1 {param-type} paramName param description\r
+     */`);
+
+  const source = [
+    {
+      number: 1,
+      source: '    /**',
+      tokens: {
+        ...tokens,
+        start: '    ',
+        delimiter: '/**',
+      },
+    },
+    {
+      number: 2,
+      source: '     * description\r',
+      tokens: {
+        ...tokens,
+        start: '     ',
+        delimiter: '*',
+        postDelimiter: ' ',
+        description: 'description\r',
+      },
+    },
+    {
+      number: 3,
+      source: '     * @param0 {param-type}\r',
+      tokens: {
+        ...tokens,
+        start: '     ',
+        delimiter: '*',
+        postDelimiter: ' ',
+        tag: '@param0',
+        postTag: ' ',
+        type: '{param-type}',
+        postType: '\r',
+      },
+    },
+    {
+      number: 4,
+      source: '     * @param1 {param-type} paramName param description\r',
+      tokens: {
+        ...tokens,
+        start: '     ',
+        delimiter: '*',
+        postDelimiter: ' ',
+        tag: '@param1',
+        postTag: ' ',
+        type: '{param-type}',
+        postType: ' ',
+        name: 'paramName',
+        postName: ' ',
+        description: 'param description\r',
+      },
+    },
+    {
+      number: 5,
+      source: '     */',
+      tokens: {
+        ...tokens,
+        start: '     ',
+        end: '*/',
+      },
+    },
+  ];
+
+  expect(parsed[0]).toMatchObject({
+    description: 'description',
+    problems: [],
+    source,
+    tags: [
+      {
+        tag: 'param0',
+        type: 'param-type',
+        name: '',
+        optional: false,
+        description: '',
+        source: [source[2]],
+      },
+      {
+        tag: 'param1',
+        type: 'param-type',
+        name: 'paramName',
+        optional: false,
+        description: 'param description',
+        source: [source[3], source[4]],
+      },
+    ],
+  });
+});

--- a/tests/e2e/issue-129.spec.js
+++ b/tests/e2e/issue-129.spec.js
@@ -1,4 +1,4 @@
-const { parse, inspect } = require('../../lib');
+const { parse, inspect } = require('../../lib/index.cjs');
 
 const tokens = {
   start: '',

--- a/tests/e2e/issue-129.spec.js
+++ b/tests/e2e/issue-129.spec.js
@@ -1,4 +1,9 @@
-const { parse, inspect } = require('../../lib/index.cjs');
+const {
+  parse,
+  inspect,
+  stringify,
+  transforms: { align },
+} = require('../../lib');
 
 const tokens = {
   start: '',
@@ -108,4 +113,28 @@ test('carriage returns', () => {
       },
     ],
   });
+});
+
+test('carriage returns with alignment', () => {
+  const source = `
+     /**\r
+      * Description may go\r
+      * over multiple lines followed by @tags\r
+      *  @param {string} name the name parameter\r
+      *     @param {any} value\r
+      */\r`.slice(1);
+
+  const expected = `
+     /**
+      * Description may go
+      * over multiple lines followed by @tags
+      * @param {string} name  the name parameter
+      * @param {any}    value
+      */`.slice(1);
+
+  const parsed = parse(source);
+  const aligned = align()(parsed[0]);
+  const stringified = stringify(aligned);
+
+  expect(stringified).toEqual(expected);
 });

--- a/tests/e2e/issue-41.spec.js
+++ b/tests/e2e/issue-41.spec.js
@@ -34,6 +34,7 @@ test('quoted name', () => {
                 postType: '',
                 description: '- Here you can find all the brand colors...',
                 end: '',
+                lineEnd: '',
               },
             },
             {
@@ -51,6 +52,7 @@ test('quoted name', () => {
                 postType: '',
                 description: '',
                 end: '*/',
+                lineEnd: '',
               },
             },
           ],
@@ -72,6 +74,7 @@ test('quoted name', () => {
             postType: '',
             description: '',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -90,6 +93,7 @@ test('quoted name', () => {
             postType: '',
             description: '- Here you can find all the brand colors...',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -107,6 +111,7 @@ test('quoted name', () => {
             postType: '',
             description: '',
             end: '*/',
+            lineEnd: '',
           },
         },
       ],
@@ -149,6 +154,7 @@ test('optional name', () => {
                 postType: '',
                 description: '- Here you can find all the brand colors...',
                 end: '',
+                lineEnd: '',
               },
             },
             {
@@ -166,6 +172,7 @@ test('optional name', () => {
                 postType: '',
                 description: '',
                 end: '*/',
+                lineEnd: '',
               },
             },
           ],
@@ -187,6 +194,7 @@ test('optional name', () => {
             postType: '',
             description: '',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -205,6 +213,7 @@ test('optional name', () => {
             postType: '',
             description: '- Here you can find all the brand colors...',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -222,6 +231,7 @@ test('optional name', () => {
             postType: '',
             description: '',
             end: '*/',
+            lineEnd: '',
           },
         },
       ],
@@ -265,6 +275,7 @@ test('inconsistent quotes', () => {
                 description:
                   'Colors - Here you can find all the brand colors...',
                 end: '',
+                lineEnd: '',
               },
             },
             {
@@ -282,6 +293,7 @@ test('inconsistent quotes', () => {
                 postType: '',
                 description: '',
                 end: '*/',
+                lineEnd: '',
               },
             },
           ],
@@ -303,6 +315,7 @@ test('inconsistent quotes', () => {
             postType: '',
             description: '',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -321,6 +334,7 @@ test('inconsistent quotes', () => {
             postType: '',
             description: 'Colors - Here you can find all the brand colors...',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -338,6 +352,7 @@ test('inconsistent quotes', () => {
             postType: '',
             description: '',
             end: '*/',
+            lineEnd: '',
           },
         },
       ],

--- a/tests/e2e/issue-41.spec.js
+++ b/tests/e2e/issue-41.spec.js
@@ -1,4 +1,4 @@
-const { default: getParser } = require('../../lib/parser');
+const { default: getParser } = require('../../lib/parser/index.cjs');
 
 test('quoted name', () => {
   const parsed = getParser()(`

--- a/tests/e2e/issue-61.spec.js
+++ b/tests/e2e/issue-61.spec.js
@@ -1,4 +1,4 @@
-const { default: getParser } = require('../../lib/parser');
+const { default: getParser } = require('../../lib/parser/index.cjs');
 
 test('fenced description', () => {
   const parsed = getParser({ spacing: 'preserve' })(`

--- a/tests/e2e/issue-61.spec.js
+++ b/tests/e2e/issue-61.spec.js
@@ -25,6 +25,7 @@ class Foo { }
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -42,6 +43,7 @@ class Foo { }
         postType: '',
         description: '```ts',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -59,6 +61,7 @@ class Foo { }
         postType: '',
         description: '@transient()',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -76,6 +79,7 @@ class Foo { }
         postType: '',
         description: 'class Foo { }',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -93,6 +97,7 @@ class Foo { }
         postType: '',
         description: '```',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -110,6 +115,7 @@ class Foo { }
         postType: '',
         description: '',
         end: '*/',
+        lineEnd: '',
       },
     },
   ];
@@ -155,6 +161,7 @@ test('fenced one-liner', () => {
         postType: '',
         description: '```ts @transient() class Foo { } ```',
         end: '*/',
+        lineEnd: '',
       },
     },
   ];
@@ -207,6 +214,7 @@ text
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -224,6 +232,7 @@ text
         postType: '',
         description: '```ts',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -241,6 +250,7 @@ text
         postType: '',
         description: '@one',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -258,6 +268,7 @@ text
         postType: '',
         description: '```',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -275,6 +286,7 @@ text
         postType: '',
         description: 'text',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -292,6 +304,7 @@ text
         postType: '',
         description: '```',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -309,6 +322,7 @@ text
         postType: '',
         description: '@two',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -326,6 +340,7 @@ text
         postType: '',
         description: '```',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -343,6 +358,7 @@ text
         postType: '',
         description: '',
         end: '*/',
+        lineEnd: '',
       },
     },
   ];
@@ -395,6 +411,7 @@ text
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -412,6 +429,7 @@ text
         postType: '',
         description: '###ts',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -429,6 +447,7 @@ text
         postType: '',
         description: '@one',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -446,6 +465,7 @@ text
         postType: '',
         description: '###',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -463,6 +483,7 @@ text
         postType: '',
         description: 'text',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -480,6 +501,7 @@ text
         postType: '',
         description: '###',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -497,6 +519,7 @@ text
         postType: '',
         description: '@two',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -514,6 +537,7 @@ text
         postType: '',
         description: '###',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -531,6 +555,7 @@ text
         postType: '',
         description: '',
         end: '*/',
+        lineEnd: '',
       },
     },
   ];

--- a/tests/e2e/parse.spec.js
+++ b/tests/e2e/parse.spec.js
@@ -1,4 +1,4 @@
-const { parse } = require('../../lib');
+const { parse } = require('../../lib/index.cjs');
 
 test('description only', () => {
   const parsed = parse(`

--- a/tests/e2e/parse.spec.js
+++ b/tests/e2e/parse.spec.js
@@ -25,6 +25,7 @@ test('description only', () => {
             postType: '',
             description: '',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -42,6 +43,7 @@ test('description only', () => {
             postType: '',
             description: 'Description',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -59,6 +61,7 @@ test('description only', () => {
             postType: '',
             description: '',
             end: '*/',
+            lineEnd: '',
           },
         },
       ],
@@ -91,6 +94,7 @@ test('description one-liner', () => {
             postType: '',
             description: 'Description ',
             end: '*/',
+            lineEnd: '',
           },
         },
       ],
@@ -123,6 +127,7 @@ test('block closed on same line', () => {
             postType: '',
             description: '',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -140,6 +145,7 @@ test('block closed on same line', () => {
             postType: '',
             description: 'Description ',
             end: '*/',
+            lineEnd: '',
           },
         },
       ],
@@ -173,6 +179,7 @@ test('no mid stars', () => {
             postType: '',
             description: '',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -190,6 +197,7 @@ test('no mid stars', () => {
             postType: '',
             description: 'Description',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -207,6 +215,7 @@ test('no mid stars', () => {
             postType: '',
             description: '',
             end: '*/',
+            lineEnd: '',
           },
         },
       ],
@@ -246,6 +255,7 @@ test('skip surrounding empty lines while preserving line numbers', () => {
             postType: '',
             description: '',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -263,6 +273,7 @@ test('skip surrounding empty lines while preserving line numbers', () => {
             postType: '',
             description: '',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -280,6 +291,7 @@ test('skip surrounding empty lines while preserving line numbers', () => {
             postType: '',
             description: '',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -297,6 +309,7 @@ test('skip surrounding empty lines while preserving line numbers', () => {
             postType: '',
             description: 'Description first line',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -314,6 +327,7 @@ test('skip surrounding empty lines while preserving line numbers', () => {
             postType: '',
             description: '',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -331,6 +345,7 @@ test('skip surrounding empty lines while preserving line numbers', () => {
             postType: '',
             description: 'Description second line',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -348,6 +363,7 @@ test('skip surrounding empty lines while preserving line numbers', () => {
             postType: '',
             description: '',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -365,6 +381,7 @@ test('skip surrounding empty lines while preserving line numbers', () => {
             postType: '',
             description: '',
             end: '*/',
+            lineEnd: '',
           },
         },
       ],
@@ -400,6 +417,7 @@ test('description on the first line', () => {
             postType: '',
             description: 'Description first line',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -417,6 +435,7 @@ test('description on the first line', () => {
             postType: '',
             description: '',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -434,6 +453,7 @@ test('description on the first line', () => {
             postType: '',
             description: 'Description second line',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -451,6 +471,7 @@ test('description on the first line', () => {
             postType: '',
             description: '',
             end: '*/',
+            lineEnd: '',
           },
         },
       ],
@@ -502,6 +523,7 @@ test('multiple blocks', () => {
             postType: '',
             description: '',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -519,6 +541,7 @@ test('multiple blocks', () => {
             postType: '',
             description: 'Description first line',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -536,6 +559,7 @@ test('multiple blocks', () => {
             postType: '',
             description: '',
             end: '*/',
+            lineEnd: '',
           },
         },
       ],
@@ -560,6 +584,7 @@ test('multiple blocks', () => {
             postType: '',
             description: '',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -577,6 +602,7 @@ test('multiple blocks', () => {
             postType: '',
             description: 'Description second line',
             end: '',
+            lineEnd: '',
           },
         },
         {
@@ -594,6 +620,7 @@ test('multiple blocks', () => {
             postType: '',
             description: '',
             end: '*/',
+            lineEnd: '',
           },
         },
       ],
@@ -638,6 +665,7 @@ test('tag only one-liner', () => {
         postType: '',
         description: '',
         end: '*/',
+        lineEnd: '',
       },
     },
   ];
@@ -684,6 +712,7 @@ test('tag only', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -701,6 +730,7 @@ test('tag only', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -718,6 +748,7 @@ test('tag only', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -735,6 +766,7 @@ test('tag only', () => {
         postType: '',
         description: '',
         end: '*/',
+        lineEnd: '',
       },
     },
   ];
@@ -781,6 +813,7 @@ test('tag and type only', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -798,6 +831,7 @@ test('tag and type only', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -815,6 +849,7 @@ test('tag and type only', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -832,6 +867,7 @@ test('tag and type only', () => {
         postType: '',
         description: '',
         end: '*/',
+        lineEnd: '',
       },
     },
   ];
@@ -878,6 +914,7 @@ test('tag and name only', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -895,6 +932,7 @@ test('tag and name only', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -912,6 +950,7 @@ test('tag and name only', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -929,6 +968,7 @@ test('tag and name only', () => {
         postType: '',
         description: '',
         end: '*/',
+        lineEnd: '',
       },
     },
   ];
@@ -975,6 +1015,7 @@ test('tag, type, and name', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -992,6 +1033,7 @@ test('tag, type, and name', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1009,6 +1051,7 @@ test('tag, type, and name', () => {
         postType: ' ',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1026,6 +1069,7 @@ test('tag, type, and name', () => {
         postType: '',
         description: '',
         end: '*/',
+        lineEnd: '',
       },
     },
   ];
@@ -1072,6 +1116,7 @@ test('tag, type, name, and description', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1089,6 +1134,7 @@ test('tag, type, name, and description', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1106,6 +1152,7 @@ test('tag, type, name, and description', () => {
         postType: ' ',
         description: 'description text',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1123,6 +1170,7 @@ test('tag, type, name, and description', () => {
         postType: '',
         description: '',
         end: '*/',
+        lineEnd: '',
       },
     },
   ];
@@ -1169,6 +1217,7 @@ test('description contains /**', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1186,6 +1235,7 @@ test('description contains /**', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1203,6 +1253,7 @@ test('description contains /**', () => {
         postType: ' ',
         description: 'description text /**',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1220,6 +1271,7 @@ test('description contains /**', () => {
         postType: '',
         description: '',
         end: '*/',
+        lineEnd: '',
       },
     },
   ];
@@ -1266,6 +1318,7 @@ test('tag, type, name, and description separated by mixed spaces', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1283,6 +1336,7 @@ test('tag, type, name, and description separated by mixed spaces', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1300,6 +1354,7 @@ test('tag, type, name, and description separated by mixed spaces', () => {
         postType: '\t ',
         description: 'description text',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1317,6 +1372,7 @@ test('tag, type, name, and description separated by mixed spaces', () => {
         postType: '',
         description: '',
         end: '*/',
+        lineEnd: '',
       },
     },
   ];
@@ -1364,6 +1420,7 @@ test('tag with multiline description', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1381,6 +1438,7 @@ test('tag with multiline description', () => {
         postType: ' ',
         description: 'description line 1',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1398,6 +1456,7 @@ test('tag with multiline description', () => {
         postType: '',
         description: 'description line 2',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1415,6 +1474,7 @@ test('tag with multiline description', () => {
         postType: '',
         description: 'description line 3',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1432,6 +1492,7 @@ test('tag with multiline description', () => {
         postType: '',
         description: '',
         end: '*/',
+        lineEnd: '',
       },
     },
   ];
@@ -1479,6 +1540,7 @@ test('optional name', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1496,6 +1558,7 @@ test('optional name', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1513,6 +1576,7 @@ test('optional name', () => {
         postType: ' ',
         description: 'description text',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1530,6 +1594,7 @@ test('optional name', () => {
         postType: '',
         description: '',
         end: '*/',
+        lineEnd: '',
       },
     },
   ];
@@ -1576,6 +1641,7 @@ test('report name errors', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1593,6 +1659,7 @@ test('report name errors', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1610,6 +1677,7 @@ test('report name errors', () => {
         postType: ' ',
         description: '[my-name description text',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1627,6 +1695,7 @@ test('report name errors', () => {
         postType: '',
         description: '',
         end: '*/',
+        lineEnd: '',
       },
     },
   ];
@@ -1682,6 +1751,7 @@ test('misaligned block', () => {
         postType: '',
         description: '',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1699,6 +1769,7 @@ test('misaligned block', () => {
         postType: ' ',
         description: 'description line 1',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1716,6 +1787,7 @@ test('misaligned block', () => {
         postType: '',
         description: 'description line 2',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1733,6 +1805,7 @@ test('misaligned block', () => {
         postType: '',
         description: 'description line 3',
         end: '',
+        lineEnd: '',
       },
     },
     {
@@ -1750,6 +1823,7 @@ test('misaligned block', () => {
         postType: '',
         description: '',
         end: '*/',
+        lineEnd: '',
       },
     },
   ];

--- a/tests/e2e/stringify.spec.js
+++ b/tests/e2e/stringify.spec.js
@@ -1,4 +1,4 @@
-const { parse, stringify } = require('../../lib/');
+const { parse, stringify } = require('../../lib/index.cjs');
 
 test('preserve formatting', () => {
   const source = `

--- a/tests/e2e/transforms.spec.js
+++ b/tests/e2e/transforms.spec.js
@@ -2,7 +2,7 @@ const {
   parse,
   stringify,
   transforms: { flow, indent, align },
-} = require('../../lib/');
+} = require('../../lib/index.cjs');
 
 test('align + indent', () => {
   const source = `

--- a/tests/unit/inspect.spec.ts
+++ b/tests/unit/inspect.spec.ts
@@ -5,22 +5,22 @@ import { seedBlock } from '../../src/util';
 test('multiple lines', () => {
   const source = `
   /**
-   * Description may go
-   * over few lines followed by @tags
+   * Description may go\r\r
+   * over few lines followed by @tags\r
    * @param {string} name name parameter
    * @param {any} value value of any type
    */`.slice(1);
 
   const parsed = getParser()(source);
   const expected = `
-|line|start|delimiter|postDelimiter|tag   |postTag|name |postName|type    |postType|description                     |end|
-|----|-----|---------|-------------|------|-------|-----|--------|--------|--------|--------------------------------|---|
-|   0|{2}  |/**      |             |      |       |     |        |        |        |                                |   |
-|   1|{3}  |*        |{1}          |      |       |     |        |        |        |Description may go              |   |
-|   2|{3}  |*        |{1}          |      |       |     |        |        |        |over few lines followed by @tags|   |
-|   3|{3}  |*        |{1}          |@param|{1}    |name |{1}     |{string}|{1}     |name parameter                  |   |
-|   4|{3}  |*        |{1}          |@param|{1}    |value|{1}     |{any}   |{1}     |value of any type               |   |
-|   5|{3}  |         |             |      |       |     |        |        |        |                                |*/ |`;
+|line|start|delimiter|postDelimiter|tag   |postTag|name |postName|type    |postType|description                     |end|CR |
+|----|-----|---------|-------------|------|-------|-----|--------|--------|--------|--------------------------------|---|---|
+|   0|{2}  |/**      |             |      |       |     |        |        |        |                                |   |   |
+|   1|{3}  |*        |{1}          |      |       |     |        |        |        |Description may go              |   |{2}|
+|   2|{3}  |*        |{1}          |      |       |     |        |        |        |over few lines followed by @tags|   |{1}|
+|   3|{3}  |*        |{1}          |@param|{1}    |name |{1}     |{string}|{1}     |name parameter                  |   |   |
+|   4|{3}  |*        |{1}          |@param|{1}    |value|{1}     |{any}   |{1}     |value of any type               |   |   |
+|   5|{3}  |         |             |      |       |     |        |        |        |                                |*/ |   |`;
 
   expect(inspect(parsed[0])).toEqual(expected.slice(1));
 });
@@ -29,9 +29,9 @@ test('single line', () => {
   const source = '/** @param {string} name name parameter */';
   const parsed = getParser({ startLine: 12345 })(source);
   const expected = `
-|line |start|delimiter|postDelimiter|tag   |postTag|name|postName|type    |postType|description    |end|
-|-----|-----|---------|-------------|------|-------|----|--------|--------|--------|---------------|---|
-|12345|     |/**      |{1}          |@param|{1}    |name|{1}     |{string}|{1}     |name parameter |*/ |`;
+|line |start|delimiter|postDelimiter|tag   |postTag|name|postName|type    |postType|description    |end|CR|
+|-----|-----|---------|-------------|------|-------|----|--------|--------|--------|---------------|---|--|
+|12345|     |/**      |{1}          |@param|{1}    |name|{1}     |{string}|{1}     |name parameter |*/ |  |`;
 
   expect(inspect(parsed[0])).toEqual(expected.slice(1));
 });

--- a/tests/unit/source-parser.spec.ts
+++ b/tests/unit/source-parser.spec.ts
@@ -241,7 +241,8 @@ test('carriage returns', () => {
     ['/**', ' * description', ' *', ' */', ''].join('\r\n')
   );
 
-  const parsed = source.map(getParser());
+  const parse = getParser();
+  const parsed = source.map(parse);
 
   const block = [
     {
@@ -249,7 +250,7 @@ test('carriage returns', () => {
       source: '/**\r',
       tokens: seedTokens({
         delimiter: '/**',
-        postDelimiter: '\r',
+        lineEnd: '\r',
       }),
     },
     {
@@ -259,7 +260,8 @@ test('carriage returns', () => {
         start: ' ',
         delimiter: '*',
         postDelimiter: ' ',
-        description: 'description\r',
+        description: 'description',
+        lineEnd: '\r',
       }),
     },
     {
@@ -268,7 +270,7 @@ test('carriage returns', () => {
       tokens: seedTokens({
         start: ' ',
         delimiter: '*',
-        postDelimiter: '\r',
+        lineEnd: '\r',
       }),
     },
     {
@@ -276,7 +278,8 @@ test('carriage returns', () => {
       source: ' */\r',
       tokens: seedTokens({
         start: ' ',
-        end: '*/\r',
+        end: '*/',
+        lineEnd: '\r',
       }),
     },
   ];

--- a/tests/unit/source-parser.spec.ts
+++ b/tests/unit/source-parser.spec.ts
@@ -1,5 +1,5 @@
 import getParser, { Parser } from '../../src/parser/source-parser';
-import { Block, Line } from '../../src/primitives';
+import { Line } from '../../src/primitives';
 import { splitLines, seedBlock, seedTokens } from '../../src/util';
 
 let _parse: Parser;
@@ -234,4 +234,52 @@ test('start line number', () => {
   ];
 
   expect(parsed).toEqual([null, block]);
+});
+
+test('carriage returns', () => {
+  const source = splitLines(
+    ['/**', ' * description', ' *', ' */', ''].join('\r\n')
+  );
+
+  const parsed = source.map(getParser());
+
+  const block = [
+    {
+      number: 0,
+      source: '/**\r',
+      tokens: seedTokens({
+        delimiter: '/**',
+        postDelimiter: '\r',
+      }),
+    },
+    {
+      number: 1,
+      source: ' * description\r',
+      tokens: seedTokens({
+        start: ' ',
+        delimiter: '*',
+        postDelimiter: ' ',
+        description: 'description\r',
+      }),
+    },
+    {
+      number: 2,
+      source: ' *\r',
+      tokens: seedTokens({
+        start: ' ',
+        delimiter: '*',
+        postDelimiter: '\r',
+      }),
+    },
+    {
+      number: 3,
+      source: ' */\r',
+      tokens: seedTokens({
+        start: ' ',
+        end: '*/\r',
+      }),
+    },
+  ];
+
+  expect(parsed).toEqual([...nulls(3), block, null]);
 });

--- a/tests/unit/stringifier.spec.ts
+++ b/tests/unit/stringifier.spec.ts
@@ -16,6 +16,7 @@ const source = [
       postType: '',
       description: '',
       end: '',
+      lineEnd: '',
     },
   },
   {
@@ -33,6 +34,7 @@ const source = [
       postType: '',
       description: 'Description may go',
       end: '',
+      lineEnd: '',
     },
   },
   {
@@ -50,6 +52,7 @@ const source = [
       postType: '',
       description: 'over multiple lines followed by @tags',
       end: '',
+      lineEnd: '',
     },
   },
   {
@@ -67,6 +70,7 @@ const source = [
       postType: '',
       description: '',
       end: '',
+      lineEnd: '',
     },
   },
   {
@@ -84,6 +88,7 @@ const source = [
       postType: ' ',
       description: 'description line 1',
       end: '',
+      lineEnd: '',
     },
   },
   {
@@ -101,6 +106,7 @@ const source = [
       postType: '',
       description: 'description line 2',
       end: '',
+      lineEnd: '',
     },
   },
   {
@@ -118,6 +124,7 @@ const source = [
       postType: '',
       description: 'description line 3',
       end: '',
+      lineEnd: '',
     },
   },
   {
@@ -135,6 +142,7 @@ const source = [
       postType: '',
       description: '',
       end: '*/',
+      lineEnd: '',
     },
   },
 ];

--- a/tests/unit/transforms-align.spec.ts
+++ b/tests/unit/transforms-align.spec.ts
@@ -139,3 +139,27 @@ test('collapse postDelimiter', () => {
 
   expect(stringified).toEqual(expected);
 });
+
+test('keep carriage returns', () => {
+  const source = `
+     /**\r
+      * Description may go\r
+      * over multiple lines followed by @tags\r
+      * @param {string} name the name parameter\r
+      * @param {any} value\r
+      */\r`.slice(1);
+
+  const expected = `
+     /**
+      * Description may go
+      * over multiple lines followed by @tags
+      * @param {string} name  the name parameter
+      * @param {any}    value
+      */`.slice(1);
+
+  const parsed = parse(source);
+  const aligned = align()(parsed[0]);
+  const stringified = stringify(aligned);
+
+  expect(stringified).toEqual(expected);
+});

--- a/tests/unit/transforms-align.spec.ts
+++ b/tests/unit/transforms-align.spec.ts
@@ -142,7 +142,7 @@ test('collapse postDelimiter', () => {
 
 test('keep carriage returns', () => {
   const source = `
-     /**\r
+     /**\r\r
       * Description may go\r
       * over multiple lines followed by @tags\r
       * @param {string} name the name parameter\r
@@ -150,12 +150,12 @@ test('keep carriage returns', () => {
       */\r`.slice(1);
 
   const expected = `
-     /**
-      * Description may go
-      * over multiple lines followed by @tags
-      * @param {string} name  the name parameter
-      * @param {any}    value
-      */`.slice(1);
+     /**\r\r
+      * Description may go\r
+      * over multiple lines followed by @tags\r
+      * @param {string} name  the name parameter\r
+      * @param {any}    value\r
+      */\r`.slice(1);
 
   const parsed = parse(source);
   const aligned = align()(parsed[0]);

--- a/tests/unit/transforms-crlf.spec.ts
+++ b/tests/unit/transforms-crlf.spec.ts
@@ -1,0 +1,70 @@
+import crlf, { Ending } from '../../src/transforms/crlf';
+import getParser, { Parser } from '../../src/parser/index';
+import getStringifier, { Stringifier } from '../../src/stringifier/index';
+
+const tests = [
+  [
+    'no CR',
+    'CRLF',
+    `
+    /**
+     * description
+     *
+     */`,
+    `
+    /**\r
+     * description\r
+     *\r
+     */\r`,
+  ],
+  [
+    'mixed',
+    'CRLF',
+    `
+    /**
+     * description
+     *\r
+     */`,
+    `
+    /**\r
+     * description\r
+     *\r
+     */\r`,
+  ],
+  [
+    'no CR',
+    'LF',
+    `
+    /**
+     * description
+     *
+     */`,
+    `
+    /**
+     * description
+     *
+     */`,
+  ],
+  [
+    'mixed',
+    'LF',
+    `
+    /**
+     * description
+     *\r
+     */`,
+    `
+    /**
+     * description
+     *
+     */`,
+  ],
+];
+
+test.each(tests)('CRLF - %s to %s', (name, mode, source, expected) => {
+  expected = expected.slice(1);
+  const parsed = getParser()(source);
+  const normalized = crlf(mode as Ending)(parsed[0]);
+  const out = getStringifier()(normalized);
+  expect(out).toBe(expected);
+});

--- a/tests/unit/util.spec.ts
+++ b/tests/unit/util.spec.ts
@@ -56,6 +56,7 @@ test('seedTokens defaults', () => {
     postType: '',
     description: '',
     end: '',
+    lineEnd: '',
   });
 });
 
@@ -72,6 +73,7 @@ test('seedTokens overrides', () => {
     postType: '',
     description: 'abc',
     end: '',
+    lineEnd: '',
   });
 });
 

--- a/tests/unit/util.spec.ts
+++ b/tests/unit/util.spec.ts
@@ -8,9 +8,9 @@ import {
 } from '../../src/util';
 
 test.each([
-  ['win', 'a\r\nb\r\nc', ['a', 'b', 'c']],
+  ['win', 'a\r\nb\r\nc', ['a\r', 'b\r', 'c']],
   ['unix', 'a\nb\nc', ['a', 'b', 'c']],
-  ['mixed', 'a\nb\r\nc', ['a', 'b', 'c']],
+  ['mixed', 'a\nb\r\nc', ['a', 'b\r', 'c']],
   ['none', 'abc', ['abc']],
 ])('spliLines - %s', (name, source, parsed) =>
   expect(splitLines(source)).toEqual(parsed)


### PR DESCRIPTION
proposed fix for #129
- keep CR as is
- add `crlf('LF' | 'CRLF')` transformation to be used with `stringify()`