### PR TITLE
Fix CommonJS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "comment-parser",
-  "version": "1.1.5",
+  "version": "1.1.6-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.1.5",
+      "version": "1.1.6-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^26.0.23",
+        "convert-extension": "^0.3.0",
         "jest": "^27.0.5",
         "prettier": "2.3.1",
         "replace": "^1.2.1",
@@ -1453,6 +1454,25 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "node_modules/convert-extension": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/convert-extension/-/convert-extension-0.3.0.tgz",
+      "integrity": "sha512-TJ3RdeL+GXOxz4jdYntfNU2vEBb4LBJppNxVD+IVZTdqvvhfthSCSh7QHi5QxSQSzsJKc8L6FgFDmeTZ/89XGA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.0",
+        "@babel/traverse": "^7.11.0",
+        "glob": "^7.1.6",
+        "mkdirp": "^1.0.4",
+        "multiline-ts": "^2.0.0"
+      },
+      "bin": {
+        "convert-extension": "build/es5/command.cjs"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
@@ -3402,6 +3422,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/multiline-ts": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multiline-ts/-/multiline-ts-2.2.0.tgz",
+      "integrity": "sha512-3BqN9bofOFEFp5ERk4ckx8aPvpLKowZCtzKC+vG8uUssSHJCr/iaCB5QI/r0t2bdRghc4UvZXe59cOl9Ph9xrQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -5751,6 +5780,19 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "convert-extension": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/convert-extension/-/convert-extension-0.3.0.tgz",
+      "integrity": "sha512-TJ3RdeL+GXOxz4jdYntfNU2vEBb4LBJppNxVD+IVZTdqvvhfthSCSh7QHi5QxSQSzsJKc8L6FgFDmeTZ/89XGA==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.11.0",
+        "@babel/traverse": "^7.11.0",
+        "glob": "^7.1.6",
+        "mkdirp": "^1.0.4",
+        "multiline-ts": "^2.0.0"
+      }
+    },
     "convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -7225,6 +7267,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "multiline-ts": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multiline-ts/-/multiline-ts-2.2.0.tgz",
+      "integrity": "sha512-3BqN9bofOFEFp5ERk4ckx8aPvpLKowZCtzKC+vG8uUssSHJCr/iaCB5QI/r0t2bdRghc4UvZXe59cOl9Ph9xrQ==",
       "dev": true
     },
     "natural-compare": {

--- a/package.json
+++ b/package.json
@@ -7,27 +7,27 @@
   "exports": {
     ".": {
       "import": "./es6/index.js",
-      "require": "./lib/index.js"
+      "require": "./lib/index.cjs"
     },
     "./primitives": {
       "import": "./es6/primitives.js",
-      "require": "./lib/primitives.js"
+      "require": "./lib/primitives.cjs"
     },
     "./util": {
       "import": "./es6/util.js",
-      "require": "./lib/util.js"
+      "require": "./lib/util.cjs"
     },
     "./parser/*": {
       "import": "./es6/parser/*.js",
-      "require": "./lib/parser/*.js"
+      "require": "./lib/parser/*.cjs"
     },
     "./stringifier/*": {
       "import": "./es6/stringifier/*.js",
-      "require": "./lib/stringifier/*.js"
+      "require": "./lib/stringifier/*.cjs"
     },
     "./transforms/*": {
       "import": "./es6/transforms/*.js",
-      "require": "./lib/transforms/*.js"
+      "require": "./lib/transforms/*.cjs"
     }
   },
   "types": "lib/index.d.ts",
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",
+    "convert-extension": "^0.3.0",
     "jest": "^27.0.5",
     "prettier": "2.3.1",
     "replace": "^1.2.1",
@@ -48,7 +49,7 @@
     "node": ">= 12.0.0"
   },
   "scripts": {
-    "build": "rimraf lib es6 browser; tsc -p tsconfig.json && tsc -p tsconfig.node.json && rollup -o browser/index.js -f iife --context window -n CommentParser es6/index.js && cd es6 && replace \"from '(\\.[^']*)'\" \"from '\\$1.js'\" * -r",
+    "build": "rimraf lib es6 browser; tsc -p tsconfig.json && tsc -p tsconfig.node.json && rollup -o browser/index.js -f iife --context window -n CommentParser es6/index.js && convert-extension cjs lib/ && cd es6 && replace \"from '(\\.[^']*)'\" \"from '\\$1.js'\" * -r --include=\"*.js\"",
     "format": "prettier --write src tests",
     "pretest": "rimraf coverage; npm run build",
     "test": "prettier --check src tests && jest --verbose",

--- a/tests/e2e/examples.spec.js
+++ b/tests/e2e/examples.spec.js
@@ -1,4 +1,9 @@
-const { parse, stringify, transforms, tokenizers } = require('../../lib');
+const {
+  parse,
+  stringify,
+  transforms,
+  tokenizers,
+} = require('../../lib/index.cjs');
 const { examples } = require('./examples');
 
 const table = examples.map((fn) => [fn.name.replace(/_/g, ' '), fn]);

--- a/tests/e2e/issue-109.spec.js
+++ b/tests/e2e/issue-109.spec.js
@@ -1,4 +1,4 @@
-const { parse, inspect } = require('../../lib');
+const { parse, inspect } = require('../../lib/index.cjs');
 
 const source = `
   /**

--- a/tests/e2e/issue-112.spec.js
+++ b/tests/e2e/issue-112.spec.js
@@ -1,4 +1,4 @@
-const { parse, inspect } = require('../../lib');
+const { parse, inspect } = require('../../lib/index.cjs');
 
 const source = `
   /**

--- a/tests/e2e/issue-113.spec.js
+++ b/tests/e2e/issue-113.spec.js
@@ -1,4 +1,4 @@
-const { parse, inspect } = require('../../lib');
+const { parse, inspect } = require('../../lib/index.cjs');
 
 const source = `
   /** Multi-line typedef for an options object type.

--- a/tests/e2e/issue-119.spec.js
+++ b/tests/e2e/issue-119.spec.js
@@ -2,7 +2,7 @@ const {
   parse,
   stringify,
   transforms: { align },
-} = require('../../lib');
+} = require('../../lib/index.cjs');
 
 test('align - ignore trailing right space', () => {
   const source = `

--- a/tests/e2e/issue-120.spec.js
+++ b/tests/e2e/issue-120.spec.js
@@ -2,7 +2,7 @@ const {
   parse,
   stringify,
   transforms: { align },
-} = require('../../lib');
+} = require('../../lib/index.cjs');
 
 test('align - collapse postDelim', () => {
   const source = `

--- a/tests/e2e/issue-121.spec.js
+++ b/tests/e2e/issue-121.spec.js
@@ -1,4 +1,4 @@
-const { parse, inspect } = require('../../lib');
+const { parse, inspect } = require('../../lib/index.cjs');
 
 test('name cut off', () => {
   const source = `

--- a/tests/e2e/issue-129.spec.js
+++ b/tests/e2e/issue-129.spec.js
@@ -1,4 +1,4 @@
-const { parse, inspect } = require('../../lib');
+const { parse, inspect } = require('../../lib/index.cjs');
 
 const tokens = {
   start: '',

--- a/tests/e2e/issue-41.spec.js
+++ b/tests/e2e/issue-41.spec.js
@@ -1,4 +1,4 @@
-const { default: getParser } = require('../../lib/parser');
+const { default: getParser } = require('../../lib/parser/index.cjs');
 
 test('quoted name', () => {
   const parsed = getParser()(`

--- a/tests/e2e/issue-61.spec.js
+++ b/tests/e2e/issue-61.spec.js
@@ -1,4 +1,4 @@
-const { default: getParser } = require('../../lib/parser');
+const { default: getParser } = require('../../lib/parser/index.cjs');
 
 test('fenced description', () => {
   const parsed = getParser({ spacing: 'preserve' })(`

--- a/tests/e2e/parse.spec.js
+++ b/tests/e2e/parse.spec.js
@@ -1,4 +1,4 @@
-const { parse } = require('../../lib');
+const { parse } = require('../../lib/index.cjs');
 
 test('description only', () => {
   const parsed = parse(`

--- a/tests/e2e/stringify.spec.js
+++ b/tests/e2e/stringify.spec.js
@@ -1,4 +1,4 @@
-const { parse, stringify } = require('../../lib/');
+const { parse, stringify } = require('../../lib/index.cjs');
 
 test('preserve formatting', () => {
   const source = `

--- a/tests/e2e/transforms.spec.js
+++ b/tests/e2e/transforms.spec.js
@@ -2,7 +2,7 @@ const {
   parse,
   stringify,
   transforms: { flow, indent, align },
-} = require('../../lib/');
+} = require('../../lib/index.cjs');
 
 test('align + indent', () => {
   const source = `


### PR DESCRIPTION
This is a fix for the beta channel, but one I think you are going to want to merge once confirmed it is working.

In my #130 PR, I had neglected to consider that the `exports` for CJS files needed to be `.cjs` given that with the change to `type: 'module'`, Node will interpret `.js` as ESM instead.

I also added `convert-extension`, a useful tool created because TypeScript has apparently insisted they will not be allowing control of output of extensions--as is needed for native ESM.

I also added an `--include=".js"` to the existing code to avoid converting paths within TypeScript files. I'm assuming those are safe to leave alone (if not required to be left alone).

Finally, I believe the tests were broken because `exports` will no longer find the `.cjs` extension. (In the future, I'd recommend switching to ESM tests, but this fixes the tests for now while they are using CJS.)

And if you are ok to merge, if I could trouble you for one more beta release...

Thanks so much!