### PR TITLE
bump `engines` per `exports` issues in earlier Node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "^4.3.4"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": "^12.20 || ^14.14.0 || ^16"
   },
   "scripts": {
     "build": "rimraf lib es6 browser; tsc -p tsconfig.json && tsc -p tsconfig.node.json && rollup -o browser/index.js -f iife --context window -n CommentParser es6/index.js && convert-extension cjs lib/ && cd es6 && replace \"from '(\\.[^']*)'\" \"from '\\$1.js'\" * -r --include=\"*.js\"",


### PR DESCRIPTION
Here's a separate PR you probably want. (We don't need it for a release ourselves as we've set the `engines`, but you might want to add it in a patch release, esp. with it coming so soon after--but whatever you want.)