### PR TITLE
fix: proper pointer for `main` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.1",
   "description": "Generic JSDoc-like comment parser",
   "type": "module",
-  "main": "lib/index.js",
+  "main": "lib/index.cjs",
   "exports": {
     ".": {
       "import": "./es6/index.js",


### PR DESCRIPTION
Current (patched?) versions of Node should be reading `exports` in priority to `main`, but the older version of Node in Atom at least (12.14.1) does not seem to be doing so.

So although this bug should not have been impacting those using the correct version range, it would still be good to fix and have a release for.