### PR TITLE
Revert "bump `engines` per `exports` issues in earlier Node versions"

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "^4.3.4"
   },
   "engines": {
-    "node": "^12.20 || ^14.14.0 || ^16"
+    "node": ">= 12.0.0"
   },
   "scripts": {
     "build": "rimraf lib es6 browser; tsc -p tsconfig.json && tsc -p tsconfig.node.json && rollup -o browser/index.js -f iife --context window -n CommentParser es6/index.js && convert-extension cjs lib/ && cd es6 && replace \"from '(\\.[^']*)'\" \"from '\\$1.js'\" * -r --include=\"*.js\"",


### PR DESCRIPTION
This reverts commit b11a8782c1c56ce2c9c84abc017f35edc526ade6.

For [issue141](https://github.com/syavorsky/comment-parser/issues/141).