### PR TITLE
Allow version 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "^4.3.4"
   },
   "engines": {
-    "node": "^12.20 || ^14.14.0 || ^16"
+    "node": "^12.20 || ^14.14.0 || ^15 || ^16"
   },
   "scripts": {
     "build": "rimraf lib es6 browser; tsc -p tsconfig.json && tsc -p tsconfig.node.json && rollup -o browser/index.js -f iife --context window -n CommentParser es6/index.js && convert-extension cjs lib/ && cd es6 && replace \"from '(\\.[^']*)'\" \"from '\\$1.js'\" * -r --include=\"*.js\"",


### PR DESCRIPTION
Allows for Node 15 without enabling all future Node versions and without enabling Node versions which will fail with subpaths.

Fixes #141 , Closes #142