### PR TITLE
Added support for custom parser markers

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,4 +1,4 @@
-import { Block, Line, Problem } from '../primitives';
+import { Block, Line, Problem, BlockMarkers, Markers } from '../primitives';
 import { splitLines } from '../util';
 import blockParser from './block-parser';
 import sourceParser from './source-parser';
@@ -18,6 +18,8 @@ export interface Options {
   fence: string;
   // block and comment description compaction strategy
   spacing: 'compact' | 'preserve';
+  // comment description markers
+  markers: BlockMarkers;
   // tokenizer functions extracting name, type, and description out of tag, see Tokenizer
   tokenizers: Tokenizer[];
 }
@@ -28,6 +30,7 @@ export default function getParser({
   startLine = 0,
   fence = '```',
   spacing = 'compact',
+  markers = Markers,
   tokenizers = [
     tokenizeTag(),
     tokenizeType(spacing),
@@ -37,7 +40,7 @@ export default function getParser({
 }: Partial<Options> = {}): Parser {
   if (startLine < 0 || startLine % 1 > 0) throw new Error('Invalid startLine');
 
-  const parseSource = sourceParser({ startLine });
+  const parseSource = sourceParser({ startLine, markers });
   const parseBlock = blockParser({ fence });
   const parseSpec = specParser({ tokenizers });
   const joinDescription = getDescriptionJoiner(spacing);
@@ -57,7 +60,7 @@ export default function getParser({
       const specs = sections.slice(1).map(parseSpec);
 
       blocks.push({
-        description: joinDescription(sections[0]),
+        description: joinDescription(sections[0], markers),
         tags: specs,
         source: lines,
         problems: specs.reduce(

--- a/src/parser/source-parser.ts
+++ b/src/parser/source-parser.ts
@@ -1,14 +1,16 @@
-import { Line, Markers, Tokens } from '../primitives';
+import { Line, Tokens, BlockMarkers, Markers } from '../primitives';
 import { seedTokens, splitSpace, splitCR } from '../util';
 
 export interface Options {
   startLine: number;
+  markers: BlockMarkers;
 }
 
 export type Parser = (source: string) => Line[] | null;
 
 export default function getParser({
   startLine = 0,
+  markers = Markers,
 }: Partial<Options> = {}): Parser {
   let block: Line[] | null = null;
   let num = startLine;
@@ -22,12 +24,12 @@ export default function getParser({
 
     if (
       block === null &&
-      rest.startsWith(Markers.start) &&
-      !rest.startsWith(Markers.nostart)
+      rest.startsWith(markers.start) &&
+      !rest.startsWith(markers.nostart)
     ) {
       block = [];
-      tokens.delimiter = rest.slice(0, Markers.start.length);
-      rest = rest.slice(Markers.start.length);
+      tokens.delimiter = rest.slice(0, markers.start.length);
+      rest = rest.slice(markers.start.length);
       [tokens.postDelimiter, rest] = splitSpace(rest);
     }
 
@@ -36,22 +38,22 @@ export default function getParser({
       return null;
     }
 
-    const isClosed = rest.trimRight().endsWith(Markers.end);
+    const isClosed = rest.trimRight().endsWith(markers.end);
 
     if (
       tokens.delimiter === '' &&
-      rest.startsWith(Markers.delim) &&
-      !rest.startsWith(Markers.end)
+      rest.startsWith(markers.delim) &&
+      !rest.startsWith(markers.end)
     ) {
-      tokens.delimiter = Markers.delim;
-      rest = rest.slice(Markers.delim.length);
+      tokens.delimiter = markers.delim;
+      rest = rest.slice(markers.delim.length);
       [tokens.postDelimiter, rest] = splitSpace(rest);
     }
 
     if (isClosed) {
       const trimmed = rest.trimRight();
-      tokens.end = rest.slice(trimmed.length - Markers.end.length);
-      rest = trimmed.slice(0, -Markers.end.length);
+      tokens.end = rest.slice(trimmed.length - markers.end.length);
+      rest = trimmed.slice(0, -markers.end.length);
     }
 
     tokens.description = rest;

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -1,8 +1,16 @@
+/** @deprecated */
 export enum Markers {
   start = '/**',
   nostart = '/***',
   delim = '*',
   end = '*/',
+}
+
+export interface BlockMarkers {
+  start: string;
+  nostart: string;
+  delim: string;
+  end: string;
 }
 
 export interface Block {

--- a/src/transforms/align.ts
+++ b/src/transforms/align.ts
@@ -1,5 +1,5 @@
 import { Transform } from './index';
-import { Markers, Block, Line } from '../primitives';
+import { BlockMarkers, Block, Line, Markers } from '../primitives';
 import { rewireSource } from '../util';
 
 interface Width {
@@ -16,16 +16,18 @@ const zeroWidth = {
   name: 0,
 };
 
-const getWidth = (w: Width, { tokens: t }: Line) => ({
-  start: t.delimiter === Markers.start ? t.start.length : w.start,
-  tag: Math.max(w.tag, t.tag.length),
-  type: Math.max(w.type, t.type.length),
-  name: Math.max(w.name, t.name.length),
-});
+const getWidth =
+  (markers = Markers) =>
+  (w: Width, { tokens: t }: Line) => ({
+    start: t.delimiter === markers.start ? t.start.length : w.start,
+    tag: Math.max(w.tag, t.tag.length),
+    type: Math.max(w.type, t.type.length),
+    name: Math.max(w.name, t.name.length),
+  });
 
 const space = (len: number) => ''.padStart(len, ' ');
 
-export default function align(): Transform {
+export default function align(markers = Markers): Transform {
   let intoTags = false;
   let w: Width;
 
@@ -40,16 +42,16 @@ export default function align(): Transform {
       tokens.description === '';
 
     // dangling '*/'
-    if (tokens.end === Markers.end && isEmpty) {
+    if (tokens.end === markers.end && isEmpty) {
       tokens.start = space(w.start + 1);
       return { ...line, tokens };
     }
 
     switch (tokens.delimiter) {
-      case Markers.start:
+      case markers.start:
         tokens.start = space(w.start);
         break;
-      case Markers.delim:
+      case markers.delim:
         tokens.start = space(w.start + 1);
         break;
       default:
@@ -101,7 +103,7 @@ export default function align(): Transform {
   }
 
   return ({ source, ...fields }: Block): Block => {
-    w = source.reduce(getWidth, { ...zeroWidth });
+    w = source.reduce(getWidth(markers), { ...zeroWidth });
     return rewireSource({ ...fields, source: source.map(update) });
   };
 }

--- a/tests/e2e/examples.js
+++ b/tests/e2e/examples.js
@@ -80,7 +80,7 @@ function parse_escaping(source, parse, stringify, transforms) {
   // parse(source, {fence: '###'}) -- update source correspondingly
 
   /**
-   * @example "some code" 
+   * @example "some code"
   ###
   @decorator
   function hello() {

--- a/tests/unit/source-parser.spec.ts
+++ b/tests/unit/source-parser.spec.ts
@@ -286,3 +286,153 @@ test('carriage returns', () => {
 
   expect(parsed).toEqual([...nulls(3), block, null]);
 });
+
+test('custom markers', () => {
+  _parse = getParser({
+    markers: {
+      start: '////',
+      nostart: '// ',
+      delim: '///',
+      end: '////',
+    },
+  });
+
+  const parsed = parse(`
+    ////
+    /// description 0
+    ///
+    /// description 1
+    ///
+    /// @param {string} value value description 0
+    \`\`\`
+    @sample code
+    \`\`\`
+    /// description 1
+    ////`);
+
+  const block = [
+    {
+      number: 1,
+      source: '    ////',
+      tokens: seedTokens({
+        start: '    ',
+        delimiter: '////',
+        postDelimiter: '',
+        description: '',
+        end: '',
+      }),
+    },
+    {
+      number: 2,
+      source: '    /// description 0',
+      tokens: seedTokens({
+        start: '    ',
+        delimiter: '///',
+        postDelimiter: ' ',
+        description: 'description 0',
+        end: '',
+      }),
+    },
+    {
+      number: 3,
+      source: '    ///',
+      tokens: seedTokens({
+        start: '    ',
+        delimiter: '///',
+        postDelimiter: '',
+        description: '',
+        end: '',
+      }),
+    },
+    {
+      number: 4,
+      source: '    /// description 1',
+      tokens: seedTokens({
+        start: '    ',
+        delimiter: '///',
+        postDelimiter: ' ',
+        description: 'description 1',
+        end: '',
+      }),
+    },
+    {
+      number: 5,
+      source: '    ///',
+      tokens: seedTokens({
+        start: '    ',
+        delimiter: '///',
+        postDelimiter: '',
+        description: '',
+        end: '',
+      }),
+    },
+    {
+      number: 6,
+      source: '    /// @param {string} value value description 0',
+      tokens: seedTokens({
+        start: '    ',
+        delimiter: '///',
+        postDelimiter: ' ',
+        description: '@param {string} value value description 0',
+        end: '',
+      }),
+    },
+    {
+      number: 7,
+      source: '    ```',
+      tokens: seedTokens({
+        start: '    ',
+        delimiter: '',
+        postDelimiter: '',
+        description: '```',
+        end: '',
+      }),
+    },
+    {
+      number: 8,
+      source: '    @sample code',
+      tokens: seedTokens({
+        start: '    ',
+        delimiter: '',
+        postDelimiter: '',
+        description: '@sample code',
+        end: '',
+      }),
+    },
+    {
+      number: 9,
+      source: '    ```',
+      tokens: seedTokens({
+        start: '    ',
+        delimiter: '',
+        postDelimiter: '',
+        description: '```',
+        end: '',
+      }),
+    },
+    {
+      number: 10,
+      source: '    /// description 1',
+      tokens: seedTokens({
+        start: '    ',
+        delimiter: '///',
+        postDelimiter: ' ',
+        description: 'description 1',
+        end: '',
+      }),
+    },
+    {
+      number: 11,
+      source: '    ////',
+      tokens: seedTokens({
+        start: '    ',
+        delimiter: '',
+        postDelimiter: '',
+        description: '',
+        end: '////',
+      }),
+    },
+  ];
+
+  expect(parsed).toEqual([...nulls(11), block]);
+});


### PR DESCRIPTION
I know this is out of the blue, but I think this would be an awesome addition to the `comment-parser` package. 

**The problem**

The `comment-parser` package currently supports only JSDoc style comments, but it is capable of being language agnostic. 

The need for this appeared after I started using `sassdoc`, that relies on the following format:

```
////
/// This is a block description
/// @param value
////
```

Since it is supposed to support just about any `xdoc` markup, I thought that extending the functionality to provide the comment markers via options would make a huge difference.

**The solution**
- Added markers as options for the functions relying on markers
- Renamed the `Markers` enum to `DefaultMarkers`
- Added a new interface for `Markers`
- Added test for parsing with custom markers