### PR TITLE
Don't publish tests or TypeScript source files

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
     }
   },
   "types": "lib/index.d.ts",
+  "files": [
+    "browser",
+    "es6",
+    "lib"
+  ],
   "directories": {
     "test": "tests"
   },


### PR DESCRIPTION
Looking at [unpkg](https://unpkg.com/browse/comment-parser@1.3.0/), you're currently publishing the tests, among other files. I don't think this is necessary.

This PR limits the published files to those in `browser`, `es6`, `lib`, `package.json`, `LICENSE` and `README.md` (the last three are [implicit with how `files` works](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#files)). I think this should cover everything `comment-parser` needs to work.

This saves about 180kB, or about half the size of the package.