### PR TITLE
allow for valid empty jsdoc; fixes #128

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -45,16 +45,12 @@ export default function getParser({
   const parseSpec = specParser({ tokenizers });
   const joinDescription = getDescriptionJoiner(spacing);
 
-  const notEmpty = (line: Line): boolean =>
-    line.tokens.description.trim() != '';
-
   return function (source: string): Block[] {
     const blocks: Block[] = [];
     for (const line of splitLines(source)) {
       const lines = parseSource(line);
 
       if (lines === null) continue;
-      if (lines.find(notEmpty) === undefined) continue;
 
       const sections = parseBlock(lines);
       const specs = sections.slice(1).map(parseSpec);

--- a/tests/e2e/parse.spec.js
+++ b/tests/e2e/parse.spec.js
@@ -480,15 +480,6 @@ test('description on the first line', () => {
   ]);
 });
 
-test('skip empty blocks', () => {
-  const parsed = parse(`
-  /**
-   *
-   */
-  var a`);
-  expect(parsed).toHaveLength(0);
-});
-
 test('multiple blocks', () => {
   const parsed = parse(`
   /**

--- a/tests/unit/parser.spec.ts
+++ b/tests/unit/parser.spec.ts
@@ -4,7 +4,7 @@ import { seedTokens } from '../../src/util';
 test('block with tags', () => {
   const parsed = getParser()(`
   /**
-   * Description may go 
+   * Description may go\x20
    * over few lines followed by @tags
    * @param {string} name name parameter
    *
@@ -167,10 +167,10 @@ test('block with tags', () => {
   ]);
 });
 
-test('no source clonning', () => {
+test('no source cloning', () => {
   const parsed = getParser()(`
   /**
-   * Description may go 
+   * Description may go\x20
    * over few lines followed by @tags
    * @param {string} name name parameter
    *
@@ -179,11 +179,111 @@ test('no source clonning', () => {
   expect(parsed[0].tags[0].source[0] === parsed[0].source[3]).toBe(true);
 });
 
+test('empty multi-line block', () => {
+  const parsed = getParser()(`
+  /**
+   *
+   */`);
+  expect(parsed).toEqual([
+    {
+      description: '',
+      tags: [],
+      source: [
+        {
+          number: 1,
+          source: '  /**',
+          tokens: {
+            delimiter: '/**',
+            description: '',
+            end: '',
+            lineEnd: '',
+            name: '',
+            postDelimiter: '',
+            postName: '',
+            postTag: '',
+            postType: '',
+            start: '  ',
+            tag: '',
+            type: '',
+          },
+        },
+        {
+          number: 2,
+          source: '   *',
+          tokens: {
+            delimiter: '*',
+            description: '',
+            end: '',
+            lineEnd: '',
+            name: '',
+            postDelimiter: '',
+            postName: '',
+            postTag: '',
+            postType: '',
+            start: '   ',
+            tag: '',
+            type: '',
+          },
+        },
+        {
+          number: 3,
+          source: '   */',
+          tokens: {
+            delimiter: '',
+            description: '',
+            end: '*/',
+            lineEnd: '',
+            name: '',
+            postDelimiter: '',
+            postName: '',
+            postTag: '',
+            postType: '',
+            start: '   ',
+            tag: '',
+            type: '',
+          },
+        },
+      ],
+      problems: [],
+    },
+  ]);
+});
+
+test('empty one-line block', () => {
+  const parsed = getParser()(`
+  /** */`);
+  expect(parsed).toEqual([
+    {
+      description: '',
+      tags: [],
+      source: [
+        {
+          number: 1,
+          source: '  /** */',
+          tokens: {
+            delimiter: '/**',
+            description: '',
+            end: '*/',
+            lineEnd: '',
+            name: '',
+            postDelimiter: ' ',
+            postName: '',
+            postTag: '',
+            postType: '',
+            start: '  ',
+            tag: '',
+            type: '',
+          },
+        },
+      ],
+      problems: [],
+    },
+  ]);
+});
+
 test.each([
-  ['empty', '/**\n*\n*/'],
   ['one-star', '/*\n*\n*/'],
   ['three-star', '/***\n*\n*/'],
-  ['empty one-liner', '/** */'],
   ['one-star oneliner', '/* */'],
   ['three-star oneliner', '/*** */'],
 ])('skip block - %s', (name, source) => {


### PR DESCRIPTION
I added the `\x20` markers at the end of line as my IDE does auto-trimming. Let me know if you need me to remove.