### PR TITLE
Fix TypeScript module resolution for node16

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -94,7 +94,9 @@ module.exports = {
   // ],
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
+  moduleNameMapper: {
+    [/(.+)\.js$/.source]: ['$1.js', '$1.ts']
+  },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   // modulePathIgnorePatterns: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "rimraf": "^3.0.2",
         "rollup": "^2.52.2",
         "ts-jest": "^27.0.3",
-        "typescript": "^4.3.4"
+        "typescript": "^4.9.5"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -4400,9 +4400,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -8018,9 +8018,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "universalify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "convert-extension": "^0.3.0",
         "jest": "^27.0.5",
         "prettier": "2.3.1",
-        "replace": "^1.2.1",
         "rimraf": "^3.0.2",
         "rollup": "^2.52.2",
         "ts-jest": "^27.0.3",
@@ -1557,15 +1556,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js": {
@@ -3752,194 +3742,6 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
-    "node_modules/replace": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/replace/-/replace-1.2.1.tgz",
-      "integrity": "sha512-KZCBe/tPanwBlbjSMQby4l+zjSiFi3CLEP/6VLClnRYgJ46DZ5u9tmA6ceWeFS8coaUnU4ZdGNb/puUGMHNSRg==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "2.4.2",
-        "minimatch": "3.0.4",
-        "yargs": "^15.3.1"
-      },
-      "bin": {
-        "replace": "bin/replace.js",
-        "search": "bin/search.js"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/replace/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/replace/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/replace/node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/replace/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/replace/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "node_modules/replace/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/replace/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/replace/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/replace/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/replace/node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/replace/node_modules/wrap-ansi/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/replace/node_modules/wrap-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/replace/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "dev": true
-    },
-    "node_modules/replace/node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/replace/node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dev": true,
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3948,12 +3750,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.20.0",
@@ -4051,12 +3847,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4526,12 +4316,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -5862,12 +5646,6 @@
       "requires": {
         "ms": "2.1.2"
       }
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
     },
     "decimal.js": {
       "version": "10.3.1",
@@ -7519,168 +7297,10 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
-    "replace": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/replace/-/replace-1.2.1.tgz",
-      "integrity": "sha512-KZCBe/tPanwBlbjSMQby4l+zjSiFi3CLEP/6VLClnRYgJ46DZ5u9tmA6ceWeFS8coaUnU4ZdGNb/puUGMHNSRg==",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.2",
-        "minimatch": "3.0.4",
-        "yargs": "^15.3.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "cliui": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
-            },
-            "color-convert": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-              "dev": true,
-              "requires": {
-                "color-name": "~1.1.4"
-              }
-            },
-            "color-name": {
-              "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-              "dev": true
-            }
-          }
-        },
-        "y18n": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "15.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-          "dev": true,
-          "requires": {
-            "cliui": "^6.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^4.1.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^4.2.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
-        }
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
-    },
-    "require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
     "resolve": {
@@ -7751,12 +7371,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "shebang-command": {
@@ -8115,12 +7729,6 @@
       "requires": {
         "isexe": "^2.0.0"
       }
-    },
-    "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.52.2",
     "ts-jest": "^27.0.3",
-    "typescript": "^4.3.4"
+    "typescript": "^4.9.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "convert-extension": "^0.3.0",
     "jest": "^27.0.5",
     "prettier": "2.3.1",
-    "replace": "^1.2.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.52.2",
     "ts-jest": "^27.0.3",
@@ -49,7 +48,7 @@
     "node": ">= 12.0.0"
   },
   "scripts": {
-    "build": "rimraf lib es6 browser; tsc -p tsconfig.json && tsc -p tsconfig.node.json && rollup -o browser/index.js -f iife --context window -n CommentParser es6/index.js && convert-extension cjs lib/ && cd es6 && replace \"from '(\\.[^']*)'\" \"from '\\$1.js'\" * -r --include=\"*.js\"",
+    "build": "rimraf lib es6 browser; tsc -p tsconfig.json && tsc -p tsconfig.node.json && rollup -o browser/index.js -f iife --context window -n CommentParser es6/index.js && convert-extension cjs lib/",
     "format": "prettier --write src tests",
     "pretest": "rimraf coverage; npm run build",
     "test": "prettier --check src tests && jest --verbose",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,23 +1,23 @@
-import getParser, { Options as ParserOptions } from './parser/index';
-import descriptionTokenizer from './parser/tokenizers/description';
-import nameTokenizer from './parser/tokenizers/name';
-import tagTokenizer from './parser/tokenizers/tag';
-import typeTokenizer from './parser/tokenizers/type';
-import getStringifier from './stringifier/index';
-import alignTransform from './transforms/align';
-import indentTransform from './transforms/indent';
-import crlfTransform from './transforms/crlf';
-import { flow as flowTransform } from './transforms/index';
-import { rewireSpecs, rewireSource, seedBlock, seedTokens } from './util';
+import getParser, { Options as ParserOptions } from './parser/index.js';
+import descriptionTokenizer from './parser/tokenizers/description.js';
+import nameTokenizer from './parser/tokenizers/name.js';
+import tagTokenizer from './parser/tokenizers/tag.js';
+import typeTokenizer from './parser/tokenizers/type.js';
+import getStringifier from './stringifier/index.js';
+import alignTransform from './transforms/align.js';
+import indentTransform from './transforms/indent.js';
+import crlfTransform from './transforms/crlf.js';
+import { flow as flowTransform } from './transforms/index.js';
+import { rewireSpecs, rewireSource, seedBlock, seedTokens } from './util.js';
 
-export * from './primitives';
+export * from './primitives.js';
 
 export function parse(source: string, options: Partial<ParserOptions> = {}) {
   return getParser(options)(source);
 }
 
 export const stringify = getStringifier();
-export { default as inspect } from './stringifier/inspect';
+export { default as inspect } from './stringifier/inspect.js';
 
 export const transforms = {
   flow: flowTransform,

--- a/src/parser/block-parser.ts
+++ b/src/parser/block-parser.ts
@@ -1,4 +1,4 @@
-import { Line } from '../primitives';
+import { Line } from '../primitives.js';
 
 const reTag = /^@\S+/;
 

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,15 +1,15 @@
-import { Block, Line, Problem, BlockMarkers, Markers } from '../primitives';
-import { splitLines } from '../util';
-import blockParser from './block-parser';
-import sourceParser from './source-parser';
-import specParser from './spec-parser';
-import { Tokenizer } from './tokenizers/index';
-import tokenizeTag from './tokenizers/tag';
-import tokenizeType from './tokenizers/type';
-import tokenizeName from './tokenizers/name';
+import { Block, Line, Problem, BlockMarkers, Markers } from '../primitives.js';
+import { splitLines } from '../util.js';
+import blockParser from './block-parser.js';
+import sourceParser from './source-parser.js';
+import specParser from './spec-parser.js';
+import { Tokenizer } from './tokenizers/index.js';
+import tokenizeTag from './tokenizers/tag.js';
+import tokenizeType from './tokenizers/type.js';
+import tokenizeName from './tokenizers/name.js';
 import tokenizeDescription, {
   getJoiner as getDescriptionJoiner,
-} from './tokenizers/description';
+} from './tokenizers/description.js';
 
 export interface Options {
   // start count for source line numbers

--- a/src/parser/source-parser.ts
+++ b/src/parser/source-parser.ts
@@ -1,5 +1,5 @@
-import { Line, Tokens, BlockMarkers, Markers } from '../primitives';
-import { seedTokens, splitSpace, splitCR } from '../util';
+import { Line, Tokens, BlockMarkers, Markers } from '../primitives.js';
+import { seedTokens, splitSpace, splitCR } from '../util.js';
 
 export interface Options {
   startLine: number;

--- a/src/parser/spec-parser.ts
+++ b/src/parser/spec-parser.ts
@@ -1,6 +1,6 @@
-import { Line, Spec } from '../primitives';
-import { seedSpec } from '../util';
-import { Tokenizer } from './tokenizers/index';
+import { Line, Spec } from '../primitives.js';
+import { seedSpec } from '../util.js';
+import { Tokenizer } from './tokenizers/index.js';
 
 export type Parser = (source: Line[]) => Spec;
 

--- a/src/parser/tokenizers/description.ts
+++ b/src/parser/tokenizers/description.ts
@@ -1,5 +1,5 @@
-import { Spec, Line, BlockMarkers, Markers } from '../../primitives';
-import { Tokenizer } from './index';
+import { Spec, Line, BlockMarkers, Markers } from '../../primitives.js';
+import { Tokenizer } from './index.js';
 
 /**
  * Walks over provided lines joining description token into a single string.

--- a/src/parser/tokenizers/index.ts
+++ b/src/parser/tokenizers/index.ts
@@ -1,4 +1,4 @@
-import { Spec } from '../../primitives';
+import { Spec } from '../../primitives.js';
 
 /**
  * Splits `spect.lines[].token.description` into other tokens,

--- a/src/parser/tokenizers/name.ts
+++ b/src/parser/tokenizers/name.ts
@@ -1,6 +1,6 @@
-import { Spec, Line } from '../../primitives';
-import { splitSpace, isSpace } from '../../util';
-import { Tokenizer } from './index';
+import { Spec, Line } from '../../primitives.js';
+import { splitSpace, isSpace } from '../../util.js';
+import { Tokenizer } from './index.js';
 
 const isQuoted = (s: string) => s && s.startsWith('"') && s.endsWith('"');
 

--- a/src/parser/tokenizers/tag.ts
+++ b/src/parser/tokenizers/tag.ts
@@ -1,5 +1,5 @@
-import { Spec } from '../../primitives';
-import { Tokenizer } from './index';
+import { Spec } from '../../primitives.js';
+import { Tokenizer } from './index.js';
 
 /**
  * Splits the `@prefix` from remaining `Spec.lines[].token.description` into the `tag` token,

--- a/src/parser/tokenizers/type.ts
+++ b/src/parser/tokenizers/type.ts
@@ -1,6 +1,6 @@
-import { Spec, Tokens } from '../../primitives';
-import { splitSpace } from '../../util';
-import { Tokenizer } from './index';
+import { Spec, Tokens } from '../../primitives.js';
+import { splitSpace } from '../../util.js';
+import { Tokenizer } from './index.js';
 
 /**
  * Joiner is a function taking collected type token string parts,

--- a/src/stringifier/index.ts
+++ b/src/stringifier/index.ts
@@ -1,4 +1,4 @@
-import { Block, Tokens } from '../primitives';
+import { Block, Tokens } from '../primitives.js';
 
 export type Stringifier = (block: Block) => string;
 

--- a/src/stringifier/inspect.ts
+++ b/src/stringifier/inspect.ts
@@ -1,5 +1,5 @@
-import { Block, Tokens } from '../primitives';
-import { isSpace } from '../util';
+import { Block, Tokens } from '../primitives.js';
+import { isSpace } from '../util.js';
 
 interface Width {
   line: number;

--- a/src/transforms/align.ts
+++ b/src/transforms/align.ts
@@ -1,6 +1,6 @@
-import { Transform } from './index';
-import { BlockMarkers, Block, Line, Markers } from '../primitives';
-import { rewireSource } from '../util';
+import { Transform } from './index.js';
+import { BlockMarkers, Block, Line, Markers } from '../primitives.js';
+import { rewireSource } from '../util.js';
 
 interface Width {
   start: number;

--- a/src/transforms/crlf.ts
+++ b/src/transforms/crlf.ts
@@ -1,6 +1,6 @@
-import { Transform } from './index';
-import { Block, Line } from '../primitives';
-import { rewireSource } from '../util';
+import { Transform } from './index.js';
+import { Block, Line } from '../primitives.js';
+import { rewireSource } from '../util.js';
 
 const order = [
   'end',

--- a/src/transforms/indent.ts
+++ b/src/transforms/indent.ts
@@ -1,6 +1,6 @@
-import { Transform } from './index';
-import { Block, Line } from '../primitives';
-import { rewireSource } from '../util';
+import { Transform } from './index.js';
+import { Block, Line } from '../primitives.js';
+import { rewireSource } from '../util.js';
 
 const pull = (offset: number) => (str) => str.slice(offset);
 const push = (offset: number) => {

--- a/src/transforms/index.ts
+++ b/src/transforms/index.ts
@@ -1,4 +1,4 @@
-import { Block } from '../primitives';
+import { Block } from '../primitives.js';
 
 export type Transform = (Block: Block) => Block;
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import { Block, Tokens, Spec, Line } from './primitives';
+import { Block, Tokens, Spec, Line } from './primitives.js';
 
 export function isSpace(source: string): boolean {
   return /^\s+$/.test(source);

--- a/tests/unit/block-parser.spec.ts
+++ b/tests/unit/block-parser.spec.ts
@@ -1,6 +1,6 @@
-import getParser from '../../src/parser/block-parser';
-import { Line } from '../../src/primitives';
-import { seedTokens } from '../../src/util';
+import getParser from '../../src/parser/block-parser.js';
+import { Line } from '../../src/primitives.js';
+import { seedTokens } from '../../src/util.js';
 
 let source: Line[];
 

--- a/tests/unit/inspect.spec.ts
+++ b/tests/unit/inspect.spec.ts
@@ -1,6 +1,6 @@
-import getParser from '../../src/parser/index';
-import inspect from '../../src/stringifier/inspect';
-import { seedBlock } from '../../src/util';
+import getParser from '../../src/parser/index.js';
+import inspect from '../../src/stringifier/inspect.js';
+import { seedBlock } from '../../src/util.js';
 
 test('multiple lines', () => {
   const source = `

--- a/tests/unit/parser.spec.ts
+++ b/tests/unit/parser.spec.ts
@@ -1,5 +1,5 @@
-import getParser from '../../src/parser';
-import { seedTokens } from '../../src/util';
+import getParser from '../../src/parser/index.js';
+import { seedTokens } from '../../src/util.js';
 
 test('block with tags', () => {
   const parsed = getParser()(`

--- a/tests/unit/source-parser.spec.ts
+++ b/tests/unit/source-parser.spec.ts
@@ -1,6 +1,6 @@
-import getParser, { Parser } from '../../src/parser/source-parser';
-import { Line } from '../../src/primitives';
-import { splitLines, seedBlock, seedTokens } from '../../src/util';
+import getParser, { Parser } from '../../src/parser/source-parser.js';
+import { Line } from '../../src/primitives.js';
+import { splitLines, seedBlock, seedTokens } from '../../src/util.js';
 
 let _parse: Parser;
 

--- a/tests/unit/spacer-description-joiner.spec.ts
+++ b/tests/unit/spacer-description-joiner.spec.ts
@@ -1,6 +1,6 @@
-import { getJoiner } from '../../src/parser/tokenizers/description';
-import { Line } from '../../src/primitives';
-import { seedTokens } from '../../src/util';
+import { getJoiner } from '../../src/parser/tokenizers/description.js';
+import { Line } from '../../src/primitives.js';
+import { seedTokens } from '../../src/util.js';
 
 const source: Line[] = [
   {

--- a/tests/unit/spec-description-tokenizer.spec.ts
+++ b/tests/unit/spec-description-tokenizer.spec.ts
@@ -1,5 +1,5 @@
-import descriptionTokenizer from '../../src/parser/tokenizers/description';
-import { seedSpec, seedTokens } from '../../src/util';
+import descriptionTokenizer from '../../src/parser/tokenizers/description.js';
+import { seedSpec, seedTokens } from '../../src/util.js';
 
 const sourceSingle = [
   {

--- a/tests/unit/spec-name-tokenizer.spec.ts
+++ b/tests/unit/spec-name-tokenizer.spec.ts
@@ -1,5 +1,5 @@
-import nameTokenizer from '../../src/parser/tokenizers/name';
-import { seedTokens, seedSpec } from '../../src/util';
+import nameTokenizer from '../../src/parser/tokenizers/name.js';
+import { seedTokens, seedSpec } from '../../src/util.js';
 
 const tokenize = nameTokenizer();
 

--- a/tests/unit/spec-parser.spec.ts
+++ b/tests/unit/spec-parser.spec.ts
@@ -1,10 +1,10 @@
-import descriptionTokenizer from '../../src/parser/tokenizers/description';
-import nameTokenizer from '../../src/parser/tokenizers/name';
-import tagTokenizer from '../../src/parser/tokenizers/tag';
-import typeTokenizer from '../../src/parser/tokenizers/type';
-import getParser from '../../src/parser/spec-parser';
-import { seedTokens, seedSpec } from '../../src/util';
-import { Spec, Problem } from '../../src/primitives';
+import descriptionTokenizer from '../../src/parser/tokenizers/description.js';
+import nameTokenizer from '../../src/parser/tokenizers/name.js';
+import tagTokenizer from '../../src/parser/tokenizers/tag.js';
+import typeTokenizer from '../../src/parser/tokenizers/type.js';
+import getParser from '../../src/parser/spec-parser.js';
+import { seedTokens, seedSpec } from '../../src/util.js';
+import { Spec, Problem } from '../../src/primitives.js';
 
 const parse = getParser({
   tokenizers: [

--- a/tests/unit/spec-tag-tokenizer.spec.ts
+++ b/tests/unit/spec-tag-tokenizer.spec.ts
@@ -1,5 +1,5 @@
-import tagTokenizer from '../../src/parser/tokenizers/tag';
-import { seedTokens, seedSpec } from '../../src/util';
+import tagTokenizer from '../../src/parser/tokenizers/tag.js';
+import { seedTokens, seedSpec } from '../../src/util.js';
 
 const tokenize = tagTokenizer();
 

--- a/tests/unit/spec-type-tokenizer.spec.ts
+++ b/tests/unit/spec-type-tokenizer.spec.ts
@@ -1,5 +1,5 @@
-import typeTokenizer, { Joiner } from '../../src/parser/tokenizers/type';
-import { seedTokens, seedSpec } from '../../src/util';
+import typeTokenizer, { Joiner } from '../../src/parser/tokenizers/type.js';
+import { seedTokens, seedSpec } from '../../src/util.js';
 
 const tokenize = typeTokenizer();
 

--- a/tests/unit/stringifier.spec.ts
+++ b/tests/unit/stringifier.spec.ts
@@ -1,4 +1,4 @@
-import getStringifier from '../../src/stringifier';
+import getStringifier from '../../src/stringifier/index.js';
 
 const source = [
   {

--- a/tests/unit/transforms-align.spec.ts
+++ b/tests/unit/transforms-align.spec.ts
@@ -1,6 +1,6 @@
-import align from '../../src/transforms/align';
-import getParser, { Parser } from '../../src/parser/index';
-import getStringifier, { Stringifier } from '../../src/stringifier/index';
+import align from '../../src/transforms/align.js';
+import getParser, { Parser } from '../../src/parser/index.js';
+import getStringifier, { Stringifier } from '../../src/stringifier/index.js';
 
 let parse: Parser;
 let stringify: Stringifier;

--- a/tests/unit/transforms-crlf.spec.ts
+++ b/tests/unit/transforms-crlf.spec.ts
@@ -1,6 +1,6 @@
-import crlf, { Ending } from '../../src/transforms/crlf';
-import getParser, { Parser } from '../../src/parser/index';
-import getStringifier, { Stringifier } from '../../src/stringifier/index';
+import crlf, { Ending } from '../../src/transforms/crlf.js';
+import getParser, { Parser } from '../../src/parser/index.js';
+import getStringifier, { Stringifier } from '../../src/stringifier/index.js';
 
 const tests = [
   [

--- a/tests/unit/transforms-indent.spec.ts
+++ b/tests/unit/transforms-indent.spec.ts
@@ -1,6 +1,6 @@
-import indent from '../../src/transforms/indent';
-import getParser from '../../src/parser/index';
-import getStringifier from '../../src/stringifier/index';
+import indent from '../../src/transforms/indent.js';
+import getParser from '../../src/parser/index.js';
+import getStringifier from '../../src/stringifier/index.js';
 
 test('push', () => {
   const source = `

--- a/tests/unit/transforms.spec.ts
+++ b/tests/unit/transforms.spec.ts
@@ -1,6 +1,6 @@
-import { flow } from '../../src/transforms/index';
-import { seedBlock } from '../../src/util';
-import { Block } from '../../src/primitives';
+import { flow } from '../../src/transforms/index.js';
+import { seedBlock } from '../../src/util.js';
+import { Block } from '../../src/primitives.js';
 
 const t0 = (b: Block): Block => ({ ...b, description: b.description + ' t0' });
 const t1 = (b: Block): Block => ({ ...b, description: b.description + ' t1' });

--- a/tests/unit/util-rewire.spec.ts
+++ b/tests/unit/util-rewire.spec.ts
@@ -1,4 +1,4 @@
-import { seedTokens, rewireSource, rewireSpecs } from '../../src/util';
+import { seedTokens, rewireSource, rewireSpecs } from '../../src/util.js';
 
 test('source to spec', () => {
   const block = {

--- a/tests/unit/util.spec.ts
+++ b/tests/unit/util.spec.ts
@@ -6,7 +6,7 @@ import {
   splitLines,
   splitSpace,
   seedSpec,
-} from '../../src/util';
+} from '../../src/util.js';
 
 test.each([
   ['beginning', '\r to end', false],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2015",
     "module": "es2015",
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "declaration": true,
     "outDir": "./es6",
     "lib": ["es2016", "es5"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2015",
-    "module": "es2015",
-    "moduleResolution": "node16",
+    "module": "node16",
     "declaration": true,
     "outDir": "./es6",
     "lib": ["es2016", "es5"]

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2015",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "declaration": true,
     "outDir": "./lib",
     "lib": ["es2016", "es5"]


### PR DESCRIPTION
This option requires imports to use a `.js` file extension. This is backwards compatible with older versions of TypeScript.

To make sure this keeps working, this project has been configured to use the `node16` module resolution as well. This required an update of TypeScript.