### PR TITLE
 Removed trailing space from ".prettierignore " file name

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+.*
+coverage

--- a/.prettierignore 
+++ b/.prettierignore 
@@ -1,2 +1,0 @@
-.*
-coverage


### PR DESCRIPTION
The `.prettierignore ` filename ends with a space, which is preventing me from checking out the repository (could be a Windows limitation).

![274237752-41eb9528-404d-41a4-aa4a-ee20db682041](https://github.com/syavorsky/comment-parser/assets/10321525/2200154f-111a-4fcf-9bd5-85b9f188f360)
