### PR TITLE
fix: support default values on non-optional names

### DIFF
--- a/.changeset/non-optional-defaults.md
+++ b/.changeset/non-optional-defaults.md
@@ -1,0 +1,5 @@
+---
+'comment-parser': patch
+---
+
+Support default values on non-optional names (e.g. `@property {number} BITMASK_VALUE_A=16 - description`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,14 @@ This script:
 4. Updates the version label in `comment-parser/index.html`
 5. Commits `package.json`, `package-lock.json`, and `comment-parser/`
 
+## Branching
+
+Always work on a dedicated branch, never directly on `main`:
+
+- **GitHub issue** → `issue-186/non-optional-defaults`
+- **Bug without an issue** → `bug/short-description`
+- **Feature without an issue** → `feature/short-description`
+
 ## Versioning & releases
 
 PRs **must** include a changeset file or carry the `skip-changeset` label (enforced by CI).

--- a/src/parser/tokenizers/name.ts
+++ b/src/parser/tokenizers/name.ts
@@ -113,6 +113,44 @@ export default function nameTokenizer(): Tokenizer {
       }
     }
 
+    if (!optional) {
+      const eqIndex = name.search(/=(?!>)/);
+      if (eqIndex !== -1) {
+        defaultValue = name.slice(eqIndex + 1).trim();
+        name = name.slice(0, eqIndex).trim();
+
+        if (name === '') {
+          spec.problems.push({
+            code: 'spec:name:empty-name',
+            message: 'empty name',
+            line: spec.source[0].number,
+            critical: true,
+          });
+          return spec;
+        }
+
+        if (defaultValue === '') {
+          spec.problems.push({
+            code: 'spec:name:empty-default',
+            message: 'empty default value',
+            line: spec.source[0].number,
+            critical: true,
+          });
+          return spec;
+        }
+
+        if (!isQuoted(defaultValue) && /=(?!>)/.test(defaultValue)) {
+          spec.problems.push({
+            code: 'spec:name:invalid-default',
+            message: 'invalid default value syntax',
+            line: spec.source[0].number,
+            critical: true,
+          });
+          return spec;
+        }
+      }
+    }
+
     spec.optional = optional;
     spec.name = name;
     tokens.name = nameToken;

--- a/tests/unit/spec-name-tokenizer.spec.ts
+++ b/tests/unit/spec-name-tokenizer.spec.ts
@@ -693,6 +693,247 @@ test('default with arrow', () => {
   );
 });
 
+test('non-optional with default', () => {
+  expect(
+    tokenize(
+      seedSpec({
+        source: [
+          {
+            number: 1,
+            source: '...',
+            tokens: seedTokens({
+              description: 'BITMASK_VALUE_A=16 description',
+            }),
+          },
+        ],
+      })
+    )
+  ).toEqual(
+    seedSpec({
+      name: 'BITMASK_VALUE_A',
+      default: '16',
+      source: [
+        {
+          number: 1,
+          source: '...',
+          tokens: seedTokens({
+            name: 'BITMASK_VALUE_A=16',
+            postName: ' ',
+            description: 'description',
+          }),
+        },
+      ],
+    })
+  );
+});
+
+test('non-optional with default, no description', () => {
+  expect(
+    tokenize(
+      seedSpec({
+        source: [
+          {
+            number: 1,
+            source: '...',
+            tokens: seedTokens({ description: 'BITMASK_VALUE_A=16' }),
+          },
+        ],
+      })
+    )
+  ).toEqual(
+    seedSpec({
+      name: 'BITMASK_VALUE_A',
+      default: '16',
+      source: [
+        {
+          number: 1,
+          source: '...',
+          tokens: seedTokens({
+            name: 'BITMASK_VALUE_A=16',
+            postName: '',
+            description: '',
+          }),
+        },
+      ],
+    })
+  );
+});
+
+test('non-optional with arrow not treated as default', () => {
+  expect(
+    tokenize(
+      seedSpec({
+        source: [
+          {
+            number: 1,
+            source: '...',
+            tokens: seedTokens({ description: 'name=>value description' }),
+          },
+        ],
+      })
+    )
+  ).toEqual(
+    seedSpec({
+      name: 'name=>value',
+      source: [
+        {
+          number: 1,
+          source: '...',
+          tokens: seedTokens({
+            name: 'name=>value',
+            postName: ' ',
+            description: 'description',
+          }),
+        },
+      ],
+    })
+  );
+});
+
+test('non-optional empty name with default', () => {
+  expect(
+    tokenize(
+      seedSpec({
+        source: [
+          {
+            number: 1,
+            source: '...',
+            tokens: seedTokens({ description: '=value description' }),
+          },
+        ],
+      })
+    )
+  ).toEqual(
+    seedSpec({
+      problems: [
+        {
+          code: 'spec:name:empty-name',
+          line: 1,
+          critical: true,
+          message: 'empty name',
+        },
+      ],
+      source: [
+        {
+          number: 1,
+          source: '...',
+          tokens: seedTokens({
+            description: '=value description',
+          }),
+        },
+      ],
+    })
+  );
+});
+
+test('non-optional empty default', () => {
+  expect(
+    tokenize(
+      seedSpec({
+        source: [
+          {
+            number: 1,
+            source: '...',
+            tokens: seedTokens({ description: 'param= description' }),
+          },
+        ],
+      })
+    )
+  ).toEqual(
+    seedSpec({
+      problems: [
+        {
+          code: 'spec:name:empty-default',
+          line: 1,
+          critical: true,
+          message: 'empty default value',
+        },
+      ],
+      source: [
+        {
+          number: 1,
+          source: '...',
+          tokens: seedTokens({
+            description: 'param= description',
+          }),
+        },
+      ],
+    })
+  );
+});
+
+test('non-optional invalid default syntax', () => {
+  expect(
+    tokenize(
+      seedSpec({
+        source: [
+          {
+            number: 1,
+            source: '...',
+            tokens: seedTokens({
+              description: 'param=value=value description',
+            }),
+          },
+        ],
+      })
+    )
+  ).toEqual(
+    seedSpec({
+      problems: [
+        {
+          code: 'spec:name:invalid-default',
+          line: 1,
+          critical: true,
+          message: 'invalid default value syntax',
+        },
+      ],
+      source: [
+        {
+          number: 1,
+          source: '...',
+          tokens: seedTokens({
+            description: 'param=value=value description',
+          }),
+        },
+      ],
+    })
+  );
+});
+
+test('non-optional dotted name with default', () => {
+  expect(
+    tokenize(
+      seedSpec({
+        source: [
+          {
+            number: 1,
+            source: '...',
+            tokens: seedTokens({
+              description: 'obj.prop=42 the property',
+            }),
+          },
+        ],
+      })
+    )
+  ).toEqual(
+    seedSpec({
+      name: 'obj.prop',
+      default: '42',
+      source: [
+        {
+          number: 1,
+          source: '...',
+          tokens: seedTokens({
+            name: 'obj.prop=42',
+            postName: ' ',
+            description: 'the property',
+          }),
+        },
+      ],
+    })
+  );
+});
+
 test('after multiline {type}', () => {
   const sourceIn = [
     {


### PR DESCRIPTION
Extends the name tokenizer to parse default values from non-optional names (e.g. `@property {number} BITMASK_VALUE_A=16 - description`), applying the same validation as optional names: empty name, empty default, and invalid default syntax all produce structured errors.

Closes #186