### PR TITLE
fix: ensure non-optional name is only broken on equal sign if prefixed by an identifier

### DIFF
--- a/.changeset/plain-lions-say.md
+++ b/.changeset/plain-lions-say.md
@@ -1,0 +1,5 @@
+---
+'comment-parser': patch
+---
+
+Ensure non-optional name is only broken on equal sign if prefixed by an identifier

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/jest": "^30.0.0",
         "convert-extension": "^0.3.0",
         "jest": "^30.1.3",
-        "prettier": "3.6.2",
+        "prettier": "3.8.3",
         "rimraf": "^6.0.1",
         "rollup": "^4.52.0",
         "ts-jest": "^29.4.4",
@@ -4969,9 +4969,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -9477,9 +9477,9 @@
       }
     },
     "prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/jest": "^30.0.0",
     "convert-extension": "^0.3.0",
     "jest": "^30.1.3",
-    "prettier": "3.6.2",
+    "prettier": "3.8.3",
     "rimraf": "^6.0.1",
     "rollup": "^4.52.0",
     "ts-jest": "^29.4.4",

--- a/src/parser/tokenizers/name.ts
+++ b/src/parser/tokenizers/name.ts
@@ -116,10 +116,10 @@ export default function nameTokenizer(): Tokenizer {
     if (!optional) {
       const eqIndex = name.search(/=(?!>)/);
       if (eqIndex !== -1) {
-        defaultValue = name.slice(eqIndex + 1).trim();
-        name = name.slice(0, eqIndex).trim();
+        const preEqual = name.slice(0, eqIndex).trim();
+        const postEqual = name.slice(eqIndex + 1).trim();
 
-        if (name === '') {
+        if (preEqual === '') {
           spec.problems.push({
             code: 'spec:name:empty-name',
             message: 'empty name',
@@ -129,7 +129,7 @@ export default function nameTokenizer(): Tokenizer {
           return spec;
         }
 
-        if (defaultValue === '') {
+        if (postEqual === '') {
           spec.problems.push({
             code: 'spec:name:empty-default',
             message: 'empty default value',
@@ -139,14 +139,21 @@ export default function nameTokenizer(): Tokenizer {
           return spec;
         }
 
-        if (!isQuoted(defaultValue) && /=(?!>)/.test(defaultValue)) {
-          spec.problems.push({
-            code: 'spec:name:invalid-default',
-            message: 'invalid default value syntax',
-            line: spec.source[0].number,
-            critical: true,
-          });
-          return spec;
+        // Only match with JS identifier (or dots) before "="
+        if (
+          /^[\p{ID_Start}$_\.][\p{ID_Continue}$_\u200c\u200d\.]*=/u.test(name)
+        ) {
+          if (!isQuoted(postEqual) && /=(?!>)/.test(postEqual)) {
+            spec.problems.push({
+              code: 'spec:name:invalid-default',
+              message: 'invalid default value syntax',
+              line: spec.source[0].number,
+              critical: true,
+            });
+            return spec;
+          }
+          name = preEqual;
+          defaultValue = postEqual;
         }
       }
     }

--- a/tests/unit/spec-name-tokenizer.spec.ts
+++ b/tests/unit/spec-name-tokenizer.spec.ts
@@ -934,6 +934,72 @@ test('non-optional dotted name with default', () => {
   );
 });
 
+test('non-optional, non-identifier name', () => {
+  expect(
+    tokenize(
+      seedSpec({
+        source: [
+          {
+            number: 1,
+            source: '...',
+            tokens: seedTokens({
+              tag: 'see',
+              description: 'https://example.com/foo?bar=baz#section',
+            }),
+          },
+        ],
+      })
+    )
+  ).toEqual(
+    seedSpec({
+      name: 'https://example.com/foo?bar=baz#section',
+      source: [
+        {
+          number: 1,
+          source: '...',
+          tokens: seedTokens({
+            tag: 'see',
+            name: 'https://example.com/foo?bar=baz#section',
+          }),
+        },
+      ],
+    })
+  );
+});
+
+test('non-optional, non-identifier name with multiple equals signs', () => {
+  expect(
+    tokenize(
+      seedSpec({
+        source: [
+          {
+            number: 1,
+            source: '...',
+            tokens: seedTokens({
+              tag: 'see',
+              description: 'https://example.com/foo?bar=baz&qux=quux',
+            }),
+          },
+        ],
+      })
+    )
+  ).toEqual(
+    seedSpec({
+      name: 'https://example.com/foo?bar=baz&qux=quux',
+      source: [
+        {
+          number: 1,
+          source: '...',
+          tokens: seedTokens({
+            tag: 'see',
+            name: 'https://example.com/foo?bar=baz&qux=quux',
+          }),
+        },
+      ],
+    })
+  );
+});
+
 test('after multiline {type}', () => {
   const sourceIn = [
     {


### PR DESCRIPTION
fix: ensure non-optional name is only broken on equal sign if prefixed by an identifier

Fixes #190 .

(I also updated prettier because that version had some issue with the executable's permissions.)